### PR TITLE
Update org.owasp/dependency-check-core to 7.4.4

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,7 @@
                org.slf4j/slf4j-nop                                     {:mvn/version "2.0.6"}
                borkdude/edamame                                        {:mvn/version "1.0.16"}
                org.clojure/tools.deps.alpha                            {:mvn/version "0.15.1254"}
-               org.owasp/dependency-check-core                         {:mvn/version "7.4.1"}
+               org.owasp/dependency-check-core                         {:mvn/version "7.4.4"}
                org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.2"}}
                
  :mvn/repos   {"central" {:url "https://repo1.maven.org/maven2/"}


### PR DESCRIPTION
When running `clj-watson` I am getting an exception with a message about an error updating 'CVE-2020-36569'

This appears to be a problem in the `dependency-check-core` dependency, with a fix in `7.4.4`. See https://github.com/jeremylong/DependencyCheck/issues/5220

Updating the dependency seems to solve the problem and I can use this tool again.

thanks!