### PR TITLE
update dependencies -- for discussion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pom.xml.asc
 .clj-kondo/*/
 target/
 .lsp/
+.portal/

--- a/deps.edn
+++ b/deps.edn
@@ -1,16 +1,17 @@
 {:deps        {org.clojure/clojure                                     {:mvn/version "1.11.1"}
                version-clj/version-clj                                 {:mvn/version "2.0.2"}
                clj-http/clj-http                                       {:mvn/version "3.12.3"}
-               cheshire/cheshire                                       {:mvn/version "5.11.0"}
+               cheshire/cheshire                                       {:mvn/version "5.12.0"}
                cli-matic/cli-matic                                     {:mvn/version "0.5.4"}
                clj-time/clj-time                                       {:mvn/version "0.15.2"}
-               selmer/selmer                                           {:mvn/version "1.12.55"}
-               org.slf4j/slf4j-nop                                     {:mvn/version "2.0.6"}
-               borkdude/edamame                                        {:mvn/version "1.0.16"}
-               org.clojure/tools.deps.alpha                            {:mvn/version "0.15.1254"}
-               org.owasp/dependency-check-core                         {:mvn/version "7.4.4"}
-               org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.2"}}
-               
+               selmer/selmer                                           {:mvn/version "1.12.59"}
+               org.slf4j/slf4j-nop                                     {:mvn/version "2.0.9"}
+               borkdude/edamame                                        {:mvn/version "1.3.23"}
+               ;; TODO: update to non-alpha
+               org.clojure/tools.deps                                  {:mvn/version "0.18.1374"}
+               org.owasp/dependency-check-core                         {:mvn/version "9.0.4"}
+               org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.18"}}
+
  :mvn/repos   {"central" {:url "https://repo1.maven.org/maven2/"}
                "clojars" {:url "https://repo.clojars.org/"}}
 

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,6 @@
                selmer/selmer                                           {:mvn/version "1.12.59"}
                org.slf4j/slf4j-nop                                     {:mvn/version "2.0.9"}
                borkdude/edamame                                        {:mvn/version "1.3.23"}
-               ;; TODO: update to non-alpha
                org.clojure/tools.deps                                  {:mvn/version "0.18.1374"}
                org.owasp/dependency-check-core                         {:mvn/version "9.0.4"}
                org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.18"}}

--- a/resources/dependency-check.properties
+++ b/resources/dependency-check.properties
@@ -1,5 +1,6 @@
-odc.application.name=${pom.name}
-odc.application.version=${pom.version}
+# replaced ${pom.*} with actual values:
+odc.application.name=clj-watson
+odc.application.version=4.1.3
 odc.autoupdate=true
 odc.analysis.timeout=30
 odc.settings.mask=.*password.*,.*token.*
@@ -19,6 +20,18 @@ data.writelock.shutdownhook=org.owasp.dependencycheck.utils.WriteLockCleanupHook
 data.driver_name=org.h2.Driver
 
 proxy.disableSchemas=true
+
+# nvd.api.key must be provided by the user:
+#nvd.api.key=...
+nvd.api.check.validforhours=12
+nvd.api.datafeed.startyear=2002
+nvd.api.datafeed.validfordays=7
+nvd.api.delay=2000
+nvd.api.max.retry.count=10
+# unused nvd.api.* keys:
+#nvd.api.datafeed.url=
+#nvd.api.datafeed.user=
+#nvd.api.datafeed.password=
 
 cve.url.modified.validfordays=7
 cve.check.validforhours=12

--- a/src/clj_watson/controller/deps.clj
+++ b/src/clj_watson/controller/deps.clj
@@ -1,8 +1,8 @@
 (ns clj-watson.controller.deps
   (:require
    [clojure.set :refer [rename-keys]]
-   [clojure.tools.deps.alpha :as deps]
-   [clojure.tools.deps.alpha.util.maven :as maven]
+   [clojure.tools.deps :as deps]
+   [clojure.tools.deps.util.maven :as maven]
    [edamame.core :refer [parse-string]])
   (:import
    (java.io File)))

--- a/src/clj_watson/controller/remediate.clj
+++ b/src/clj_watson/controller/remediate.clj
@@ -2,7 +2,7 @@
   (:require
    [clj-watson.diplomat.dependency :as diplomat.dependency]
    [clj-watson.logic.dependency :as logic.dependency]
-   [clojure.tools.deps.alpha.util.maven :as maven]
+   [clojure.tools.deps.util.maven :as maven]
    [version-clj.core :as version]))
 
 (defn ^:private parent-contains-child-version?

--- a/src/clj_watson/diplomat/dependency.clj
+++ b/src/clj_watson/diplomat/dependency.clj
@@ -1,9 +1,9 @@
 (ns clj-watson.diplomat.dependency
   (:require
-   [clojure.tools.deps.alpha :as deps]
-   [clojure.tools.deps.alpha.extensions :as ext]
-   [clojure.tools.deps.alpha.extensions.git :as git]
-   [clojure.tools.deps.alpha.util.maven :as maven]
+   [clojure.tools.deps :as deps]
+   [clojure.tools.deps.extensions :as ext]
+   [clojure.tools.deps.extensions.git :as git]
+   [clojure.tools.deps.util.maven :as maven]
    [clojure.tools.gitlibs :as gitlibs]))
 
 (defn ^:private append-sha-when-is-git-version [dependency version]


### PR DESCRIPTION
This updates the project's dependencies, including:
* switching from `tools.deps.alpha` to `tools.deps`
* updating the dependency checker from 7.4.4 to 9.0.4

The latter change is breaking: dependency checker 9.0.x requires an API key from NIST and introduces a number of new properties that are replacements for previous properties.

I've been testing this locally with my own API key. I think clj-watson could include a default key but there really needs to be a way to specify and override the `dependency-check.properties` settings. Perhaps a local, optional properties file could be looked for and merged in? Or perhaps JVM options could be supported?

While I have the `nvd.api.delay` set to `2000` which should be the default for the API usage, some people have indicated they have needed to set higher values. It also seemed that omitting it did not work correctly, despite the DC library setting its own default.