### PR TITLE
fix #43

### DIFF
--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -19,7 +19,7 @@
     (if properties-file-path
       (->> properties-file-path File. (.mergeProperties settings))
       (->> "dependency-check.properties" io/resource slurp .getBytes ByteArrayInputStream. (.mergeProperties settings)))
-    (when additional-properties-file-path
+    (if additional-properties-file-path
       (->> additional-properties-file-path File. (.mergeProperties settings))
       (some->> "clj-watson.properties" io/resource slurp .getBytes ByteArrayInputStream. (.mergeProperties settings)))
     settings))


### PR DESCRIPTION
changes `when` to `if` so `clj-watson.properties` file is picked up correctly.

Signed-off-by: Sean Corfield <sean@corfield.org>