### PR TITLE
update dependencies

### DIFF
--- a/.clj-kondo/funcool/cats/config.edn
+++ b/.clj-kondo/funcool/cats/config.edn
@@ -1,0 +1,9 @@
+{:lint-as {cats.core/mlet clojure.core/let
+           cats.core/alet clojure.core/let
+           cats.core/ap-> clojure.core/->
+           cats.core/ap->> clojure.core/->>
+           cats.core/as-ap-> clojure.core/as->
+           cats.core/->= clojure.core/->
+           cats.core/->>= clojure.core/->>
+           cats.core/as->= clojure.core/as->
+           cats.core/for clojure.core/for}}

--- a/.clj-kondo/marick/midje/config.edn
+++ b/.clj-kondo/marick/midje/config.edn
@@ -51,4 +51,30 @@
                                            =streams=>
                                            =throws=>
                                            =test=>
+                                           =throw-parse-exception=>])
+                                         (midje.sweet/tabular
+                                          [throws
+                                           contains
+                                           exactly
+                                           has
+                                           has-sufix
+                                           has-prefix
+                                           just
+                                           one-of
+                                           two-of
+                                           roughly
+                                           as-checker
+                                           truthy
+                                           falsey
+                                           irrelevant
+                                           anything
+                                           =>
+                                           =not=>
+                                           =deny=>
+                                           =expands-to=>
+                                           =future=>
+                                           =contains=>
+                                           =streams=>
+                                           =throws=>
+                                           =test=>
                                            =throw-parse-exception=>])]}}}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Prepare java
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.jdk-version }}
 
       - name: Install clojure tools-deps
@@ -61,7 +61,7 @@ jobs:
       - name: Prepare java
         uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - name: Install clojure tools-deps

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -17,26 +17,27 @@ jobs:
       matrix:
         namespace: [ unit ]
         operating-system: [ubuntu-latest]
+        jdk-version: ['11', '17', '21']
 
     runs-on: ${{ matrix.operating-system }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: ${{ matrix.jdk-version }}
 
       - name: Install clojure tools-deps
         uses: DeLaGuardo/setup-clojure@master
         with:
-          tools-deps: 1.11.1.1113
+          tools-deps: 1.11.1.1435
 
       - name: Cache Maven packages
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-tests-${{ hashFiles('**/deps.edn') }}
@@ -55,21 +56,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prepare java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@v4
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
 
       - name: Install clojure tools-deps
         uses: DeLaGuardo/setup-clojure@master
         with:
-          tools-deps: 1.10.3.1053
+          tools-deps: 1.11.1.1435
 
       - name: Cache Maven packages
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-tests-${{ hashFiles('**/deps.edn') }}
@@ -91,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: clj-holmes (Clojure)
         uses: clj-holmes/clj-holmes-action@main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 * v5.0.2 in progress
+  * Address [#48](https://github.com/clj-holmes/clj-watson/issues/48) by updating all of the project dependencies, including DependencyCheck to 9.0.8.
   * Address [#47](https://github.com/clj-holmes/clj-watson/issues/47) by printing out the optional properties read from the `clj-watson.properties` file.
   * Documentation improvements.
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,9 +5,9 @@
                clj-http/clj-http                                       {:mvn/version "3.12.3"}
                clj-time/clj-time                                       {:mvn/version "0.15.2"}
                org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.18"}
-               org.clojure/tools.deps                                  {:mvn/version "0.18.1374"}
-               org.owasp/dependency-check-core                         {:mvn/version "9.0.6"}
-               org.slf4j/slf4j-nop                                     {:mvn/version "2.0.9"}
+               org.clojure/tools.deps                                  {:mvn/version "0.18.1398"}
+               org.owasp/dependency-check-core                         {:mvn/version "9.0.8"}
+               org.slf4j/slf4j-nop                                     {:mvn/version "2.0.11"}
                selmer/selmer                                           {:mvn/version "1.12.59"}
                version-clj/version-clj                                 {:mvn/version "2.0.2"}}
 
@@ -18,17 +18,20 @@
 
  :tools/usage {:ns-default clj-watson.entrypoint}
 
- :aliases     {:nREPL       {:extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}}}
+ :aliases     {:nREPL       {:extra-deps {nrepl/nrepl {:mvn/version "1.1.0"}}}
                :outdated    {:replace-deps {olical/depot {:mvn/version "2.3.0"}}
                              :main-opts ["-m" "depot.outdated.main"]}
-               :clojure-lsp {:replace-deps {com.github.clojure-lsp/clojure-lsp-standalone {:mvn/version "2022.02.01-20.02.32"}}
+               :clojure-lsp {:replace-deps {com.github.clojure-lsp/clojure-lsp-standalone
+                                            {:mvn/version "2023.12.29-12.09.27"}}
                              :main-opts    ["-m" "clojure-lsp.main"]}
                :test        {:extra-paths ["test"]
-                             :extra-deps  {org.clojure/test.check                                         {:mvn/version "1.1.1"}
-                                           lambdaisland/kaocha                                            {:mvn/version "1.67.1055"}
-                                           nubank/mockfn                                                  {:mvn/version "0.7.0"}
-                                           nubank/state-flow                                              {:mvn/version "5.14.1"}}
+                             :extra-deps
+                             {org.clojure/test.check {:mvn/version "1.1.1"}
+                              lambdaisland/kaocha    {:mvn/version "1.87.1366"}
+                              nubank/mockfn          {:mvn/version "0.7.0"}
+                              nubank/state-flow      {:mvn/version "5.14.5"}}
                              :main-opts   ["-m" "kaocha.runner"]}
                ;; so we can run the recommended command from the README:
-               :clj-watson  {:replace-deps {io.github.clj-holmes/clj-watson {:git/tag "v5.0.1" :git/sha "d1ec6e5"}}
+               :clj-watson  {:replace-deps {io.github.clj-holmes/clj-watson
+                                            {:git/tag "v5.0.1" :git/sha "d1ec6e5"}}
                              :main-opts ["-m" "clj-watson.cli" "scan"]}}}

--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -3,7 +3,7 @@
    [clojure.java.io :as io]
    [clojure.string :as string])
   (:import
-   (java.io File ByteArrayInputStream)
+   (java.io ByteArrayInputStream File)
    (java.util Arrays)
    (org.owasp.dependencycheck Engine)
    (org.owasp.dependencycheck.utils Settings)))


### PR DESCRIPTION
DependencyCheck -> 9.0.8

but also all the other outdated deps, including in the GH workflow

Signed-off-by: Sean Corfield <sean@corfield.org>