### PR TITLE
Suppress noisy logging from Apache Commons JCS

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,9 @@
                org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.18"}
                org.clojure/tools.deps                                  {:mvn/version "0.18.1398"}
                org.owasp/dependency-check-core                         {:mvn/version "10.0.3"}
-               org.slf4j/slf4j-nop                                     {:mvn/version "2.0.11"}
+               org.slf4j/slf4j-api                                     {:mvn/version "2.0.13"}
+               ch.qos.logback/logback-classic                          {:mvn/version "1.5.6"}
+               org.apache.logging.log4j/log4j-to-slf4j                 {:mvn/version "2.23.1"}
                selmer/selmer                                           {:mvn/version "1.12.59"}
                version-clj/version-clj                                 {:mvn/version "2.0.2"}}
 

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+  <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d %highlight(%level) %logger{0} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <!-- Apache Commons JCS is very noisy at the INFO level -->
+  <logger name="org.apache.commons.jcs3" level="WARN" additivity="false">
+    <appender-ref ref="CONSOLE"/>
+  </logger>
+
+  <root level="INFO">
+    <appender-ref ref="CONSOLE"/>
+   </root>
+</configuration>

--- a/src/clj_watson/entrypoint.clj
+++ b/src/clj_watson/entrypoint.clj
@@ -26,6 +26,8 @@
 
 (defmethod scan* :dependency-check [{:keys [deps-edn-path suggest-fix aliases
                                             dependency-check-properties clj-watson-properties]}]
+  ;; dependency-check uses Apache Commons JCS, ask it to use log4j2 to allow us to configure its noisy logging
+  (System/setProperty "jcs.logSystem" "log4j2")
   (let [{:keys [deps dependencies]} (controller.deps/parse deps-edn-path aliases)
         repositories (select-keys deps [:mvn/repos])
         scanned-dependencies (controller.dc.scanner/start! dependencies


### PR DESCRIPTION
We could have continued with slf4-nop, but I opted to switch to logback-classic to exercise suppression of Apache Commons JCS `INFO` level logging.

This enables logging in general. Relates to:
- #68 you'll see dependency-check logging during db download/update
- #67 you'll see dependency-check warn about lack of nvd api key

I chose a log pattern I thought might work. We can revisit, if necessary, in a separate issue.

Closes #69