### PR TITLE
Improve command line experience

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -90,5 +90,6 @@ jobs:
       - name: clj-holmes (Clojure)
         uses: clj-holmes/clj-holmes-action@main
         with:
+          tags: 'security'
           output-type: 'stdout'
           fail-on-result: 'true'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -90,6 +90,5 @@ jobs:
       - name: clj-holmes (Clojure)
         uses: clj-holmes/clj-holmes-action@main
         with:
-          tags: 'security'
           output-type: 'stdout'
           fail-on-result: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+* Unreleased
+  * Improve command line experience [#77](https://github.com/clj-holmes/clj-watson/issues/77)
+
 * v5.1.3 5812615 -- 2024-07-31
   * Address [#60](https://github.com/clj-holmes/clj-watson/issues/60) by updating `org.owasp/dependency-check-core` to 10.0.3.
     

--- a/README.md
+++ b/README.md
@@ -226,28 +226,34 @@ clojure -M:clj-watson -p deps.edn
 You can get a full list of the available options by running:
 
 ```bash
-clojure -M:clj-watson scan -\?
+clojure -M:clj-watson scan --help
 ```
 
 This produces:
 
 ```
-NAME:
- clj-watson scan - Performs a scan on a deps.edn file
+clj-watson
 
-USAGE:
- clj-watson scan [command options] [arguments...]
+ARG USAGE:
+ scan [options..]
 
 OPTIONS:
-   -p, --deps-edn-path S*                                                      path of deps.edn to scan.
-   -o, --output edn|json|sarif|stdout|stdout-simple          stdout            Output type.
-   -a, --aliases S                                                             Specify a alias that will have the dependencies analysed alongside with the project deps.It's possible to provide multiple aliases. If a * is provided all the aliases are going to be analysed.
-   -d, --dependency-check-properties S                                         [ONLY APPLIED IF USING DEPENDENCY-CHECK STRATEGY] Path of a dependency-check properties file. If not provided uses resources/dependency-check.properties.
-   -w, --clj-watson-properties S                                               [ONLY APPLIED IF USING DEPENDENCY-CHECK STRATEGY] Path of an additional, optional properties file.
-   -t, --database-strategy dependency-check|github-advisory  dependency-check  Vulnerability database strategy.
-   -s, --[no-]suggest-fix                                    false             Suggest a new deps.edn file fixing all vulnerabilities found.
-   -f, --[no-]fail-on-result                                 false             Enable or disable fail if results were found (useful for CI/CD).
-   -?, --help
+  -p, --deps-edn-path <file>                                 Path of deps.edn file to scan [*required*]
+  -o, --output <json|edn|stdout|stdout-simple|sarif>         Output type for vulnerability findings [stdout]
+  -a, --aliases                                              Include deps.edn aliases in analysis, specify '*' for all.
+                                                             For multiple, repeat arg, ex: -a alias1 -a alias2
+  -t, --database-strategy <dependency-check|github-advisory> Vulnerability database strategy [dependency-check]
+  -s, --suggest-fix                                          Include dependency remediation suggestions in vulnurability findings [false]
+  -f, --fail-on-result                                       When enabled, exit with non-zero on any vulnerability findings
+                                                             Useful for CI/CD [false]
+  -h, --help                                                 Show usage help
+
+OPTIONS valid when database-strategy is dependency-check:
+  -d, --dependency-check-properties <file>                   Path of a dependency-check properties file
+                                                             If not provided uses resources/dependency-check.properties
+  -w, --clj-watson-properties <file>                         Path of an additional, optional properties file
+                                                             Overrides values in dependency-check.properties
+                                                             If not specified classpath is searched for cljwatson.properties
 ```
 
 By default, when using the DEPENDENCY-CHECK strategy, `clj-watson` will load

--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps        {org.clojure/clojure                                     {:mvn/version "1.11.1"}
+               org.babashka/cli                                        {:mvn/version "0.8.60"}
                borkdude/edamame                                        {:mvn/version "1.3.23"}
                cheshire/cheshire                                       {:mvn/version "5.12.0"}
-               cli-matic/cli-matic                                     {:mvn/version "0.5.4"}
                clj-http/clj-http                                       {:mvn/version "3.12.3"}
                clj-time/clj-time                                       {:mvn/version "0.15.2"}
                org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.18"}
@@ -34,7 +34,8 @@
                               nubank/mockfn          {:mvn/version "0.7.0"}
                               nubank/state-flow      {:mvn/version "5.14.5"}}
                              :main-opts   ["-m" "kaocha.runner"]}
-               ;; so we can run the recommended command from the README:
-               :clj-watson  {:replace-deps {io.github.clj-holmes/clj-watson
-                                            {:git/tag "v5.1.1" :git/sha "ad5fe07"}}
-                             :main-opts ["-m" "clj-watson.cli" "scan"]}}}
+
+               ;; for dev: so we can run the recommended command from the README:
+               :clj-watson {:replace-deps {io.github.clj-holmes/clj-watson {:local/root "."}}
+                            :main-opts ["-m" "clj-watson.cli"]
+                            :ns-default clj-watson.entrypoint}}}

--- a/src/clj_watson/cli.clj
+++ b/src/clj_watson/cli.clj
@@ -1,12 +1,10 @@
 (ns clj-watson.cli
   (:gen-class)
   (:require
-   [cli-matic.core :as cli]
-   [clj-watson.cli-spec :refer [CONFIGURATION]]
+   [clj-watson.cli-spec :as cli-spec]
    [clj-watson.entrypoint :as entrypoint]))
 
-(defn -main [& args]
-  (cli/run-cmd args
-               (update-in CONFIGURATION
-                          [:commands 0]
-                          assoc :runs entrypoint/scan)))
+(defn -main
+  "Entrypoint for -M cli usage"
+  [& args]
+  (entrypoint/do-scan (cli-spec/parse-args args)))

--- a/src/clj_watson/cli_spec.clj
+++ b/src/clj_watson/cli_spec.clj
@@ -15,8 +15,7 @@
     :ref "<file>"
     :coerce :string
     :validate validate-file-exists
-    :require :yes ;; Normally would `:require true` but clj-holmes\clj-holmes thinks this is a clojure spec
-                  ;; and raises: "Typo on schema declaration using :require instead of :required."
+    :require true
     :desc "Path of deps.edn file to scan"}
 
    :output

--- a/src/clj_watson/cli_spec.clj
+++ b/src/clj_watson/cli_spec.clj
@@ -1,76 +1,255 @@
-(ns clj-watson.cli-spec)
+(ns clj-watson.cli-spec
+  (:require
+   [babashka.cli :as cli]
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
-(def CONFIGURATION
-  {:app      {:command     "clj-watson"
-              :description "run clj-holmes" :version     (System/getProperty "clj-watson.version")}
-   :commands [{:command     "scan"
-               :description "Performs a scan on a deps.edn file"
-               :opts        [{:option  "deps-edn-path" :short "p"
-                              :type    :string
-                              :default :present
-                              :as      "path of deps.edn to scan."}
-                             {:option  "output" :short "o"
-                              :type    #{"json" "edn" "stdout" "stdout-simple" "sarif"} ; keep stdout type to avoid break current automations
-                              :default "stdout"
-                              :as      "Output type."}
-                             {:option "aliases" :short "a"
-                              :type :string
-                              :multiple true
-                              :as "Specify a alias that will have the dependencies analysed alongside with the project deps. It's possible to provide multiple aliases. If a * is provided all the aliases are going to be analysed."}
-                             {:option  "dependency-check-properties" :short "d"
-                              :type    :string
-                              :default nil
-                              :as      "[ONLY APPLIED IF USING DEPENDENCY-CHECK STRATEGY] Path of a dependency-check properties file. If not provided uses resources/dependency-check.properties."}
-                             {:option  "clj-watson-properties" :short "w"
-                              :type    :string
-                              :default nil
-                              :as      "[ONLY APPLIED IF USING DEPENDENCY-CHECK STRATEGY] Path of an additional, optional properties file."}
-                             {:option "database-strategy" :short "t"
-                              :type    #{"dependency-check" "github-advisory"}
-                              :default "dependency-check"
-                              :as      "Vulnerability database strategy."}
-                             {:option "suggest-fix" :short "s"
-                              :type    :with-flag
-                              :default false
-                              :as "Suggest a new deps.edn file fixing all vulnerabilities found."}
-                             {:option  "fail-on-result" :short "f"
-                              :type    :with-flag
-                              :default false
-                              :as      "Enable or disable fail if results were found (useful for CI/CD)."}]
-               ;; injected by clj-watson.cli to avoid circular dependency:
-               :runs        nil #_entrypoint/scan}]})
+(def valid-outputs [:json :edn :stdout :stdout-simple :sarif])
+(def valid-database-stragies [:dependency-check :github-advisory])
+(def validate-file-exists {:pred #(-> % io/file .exists)
+                           :ex-msg (fn [_m] "Specified file not found")})
 
-(def DEFAULTS
-  (into {}
-        (map (fn [{:keys [option default]}]
-               [(keyword option) (when-not (= default :present) default)]))
-        (-> CONFIGURATION :commands first :opts)))
+(def spec-scan-args
+  {:deps-edn-path
+   {:alias :p
+    :ref "<file>"
+    :coerce :string
+    :validate validate-file-exists
+    :require true
+    :desc "Path of deps.edn file to scan"}
 
-(def ABBREVIATIONS
-  (into {}
-        (map (fn [{:keys [option short]}]
-               [(keyword short) (keyword option)]))
-        (-> CONFIGURATION :commands first :opts)))
+   :output
+   {:alias :o
+    :ref (format "<%s>" (str/join "|" (mapv name valid-outputs)))
+    :coerce :keyword
+    :validate #((set valid-outputs) %)
+    :default :stdout
+    :default-desc "stdout"
+    :desc "Output type for vulnerability findings"}
 
-(defn clean-options
-  "Implement defaults for tool invocation and allow for abbreviations and
-   symbols as strings."
-  [opts]
-  (into DEFAULTS
-        (comp (map (fn [[k v]] ; expand abbreviations first:
-                     (if (and (contains? ABBREVIATIONS k)
-                              (not (contains? opts (get ABBREVIATIONS k))))
-                       [(get ABBREVIATIONS k) v]
-                       [k v])))
-              (map (fn [[k v]] ; supply defaults:
-                     (if (contains? DEFAULTS k)
-                       [k (if (some? v) v (get DEFAULTS k))]
-                       [k v])))
-              (map (fn [[k v]]
-                     [k (if (symbol? v) (str v) v)])))
-        opts))
+   :aliases
+   {:alias :a
+    :coerce [:string] ;; would coerce to keyword here, but would prefer to distinguish '*' as something special
+    :desc "Include deps.edn aliases in analysis, specify '*' for all."
+    :extra-desc {:clojure-tool "For multiple, use a vector, ex: '[alias1 alias2]'"
+                 :cli "For multiple, repeat arg, ex: -a alias1 -a alias2"}}
 
-(comment
-  (clean-options {:p 'resources/deps.edn
-                  :database-strategy 'dependency-check
-                  :s true}))
+   :database-strategy
+   {:alias :t
+    :ref (format "<%s>" (str/join "|" (mapv name valid-database-stragies)))
+    :coerce :keyword
+    :validate #((set valid-database-stragies) %)
+    :default :dependency-check
+    :default-desc "dependency-check"
+    :desc "Vulnerability database strategy"}
+
+   :suggest-fix
+   {:alias :s
+    :coerce :boolean
+    :default false
+    :desc "Include dependency remediation suggestions in vulnurability findings"}
+
+   :fail-on-result
+   {:alias :f
+    :coerce :boolean
+    :default false
+    :desc (str "When enabled, exit with non-zero on any vulnerability findings\n"
+               "Useful for CI/CD")}
+
+   :usage-help-style
+   {:coerce :keyword
+    :default :cli
+    :desc "Internal opt to control style of usage help"}
+
+   :help
+   {:alias :h
+    :coerce :boolean
+    :desc "Show usage help"}
+
+   ;; dependency-check strategy specific args follow
+   :dependency-check-properties
+   {:alias :d
+    :ref "<file>"
+    :coerce :string
+    :validate validate-file-exists
+    :desc (str "Path of a dependency-check properties file\n"
+               "If not provided uses resources/dependency-check.properties")}
+
+   :clj-watson-properties
+   {:alias :w
+    :ref "<file>"
+    :coerce :string
+    :validate validate-file-exists
+    :desc (str "Path of an additional, optional properties file\n"
+               "Overrides values in dependency-check.properties\n"
+               "If not specified classpath is searched for cljwatson.properties")}})
+
+(defn- kw->str
+  "Copied from bb cli"
+  [kw]
+  (subs (str kw) 1))
+
+(defn- cell-widths [rows]
+  (reduce
+    (fn [widths row]
+      (map max (map count row) widths)) (repeat 0) rows))
+
+(defn- pad-cells
+  "Adapted from bb cli"
+  [rows widths]
+  (let [pad-row (fn [row]
+                  (map (fn [width cell] (cli/pad width cell)) widths row))]
+    (map pad-row rows)))
+
+(defn- expand-multilines
+  "Expand last column cell over multiple rows if it contains newlines"
+  [rows]
+  (reduce (fn [acc row]
+            (let [[line & extra-lines] (-> row last str/split-lines)
+                  cols (count row)]
+              (if (seq extra-lines)
+                (apply conj acc
+                       (assoc (into [] row) (dec cols) line)
+                       (map #(conj (into [] (repeat (dec cols) ""))
+                                   %)
+                            extra-lines))
+                (conj acc row))))
+          []
+          rows))
+
+(defn- format-table
+  "Modified from bb cli format-table. Allow pre-computed widths to be passed in."
+  [{:keys [rows indent widths] :or {indent 2}}]
+  (let [widths (or widths (cell-widths rows))
+        rows (expand-multilines rows)
+        rows (pad-cells rows widths)
+        fmt-row (fn [leader divider trailer row]
+                  (str leader
+                       (apply str (interpose divider row))
+                       trailer))]
+    (->> rows
+         (map (fn [row]
+                (fmt-row (apply str (repeat indent " ")) " " "" row)))
+         (map str/trimr)
+         (str/join "\n"))))
+
+(defn- opts->table
+  "Based on bb cli opts->table."
+  [{:keys [spec order opts]}]
+  (let [usage-help-style (:usage-help-style opts)]
+    (mapv (fn [[long-opt {:keys [alias default default-desc ref desc extra-desc require]}]]
+            (keep identity
+                  [(if alias
+                     (if (= :clojure-tool usage-help-style)
+                       (str alias ",")
+                       (str "-" (kw->str alias) ","))
+                     "")
+                   (if (= :clojure-tool usage-help-style)
+                     (str long-opt " " ref)
+                     (str "--" (kw->str long-opt) " " ref))
+                   (->> [(if-let [attribute (or (when require "*required*")
+                                                default-desc
+                                                (when (some? default) (str default)))]
+                           (format "%s [%s]" desc attribute)
+                           desc)
+                         (get extra-desc usage-help-style)]
+                        (keep identity)
+                        (str/join "\n"))]))
+          (if (map? spec)
+            (let [order (or order (keys spec))]
+              (map (fn [k] [k (spec k)]) order))
+            spec))))
+
+(defn- format-opts
+  "Group-aware version of bb cli format-opts.
+  Optionally specifiy `:groups [{:heading \"My heading1\" :order [:arg1 :arg2]}]` "
+  [{:as cfg
+    :keys [groups]}]
+  (if (not groups)
+    (format-table {:rows (opts->table cfg) :indent 2})
+    (let [groups (mapv #(assoc % :rows
+                               (opts->table (assoc cfg :order (:order %))))
+                       groups)
+          widths (cell-widths (mapcat :rows groups))]
+      (->> groups
+           (reduce (fn [acc {:keys [heading rows]}]
+                     (conj acc (str heading "\n"
+                                    (format-table {:rows rows :widths widths}))))
+                   [])
+           (str/join "\n\n")))))
+
+(defn- usage-help [{:keys [opts]}]
+  (println "clj-watson")
+  (println)
+  (println "ARG USAGE:")
+  (println " scan [options..]")
+  (println)
+  (println
+   (format-opts {:spec spec-scan-args :opts opts
+                 :groups [{:heading "OPTIONS:"
+                           :order [:deps-edn-path :output :aliases :database-strategy :suggest-fix :fail-on-result :help]}
+                          {:heading "OPTIONS valid when database-strategy is dependency-check:"
+                           :order [:dependency-check-properties :clj-watson-properties]}]})))
+
+(defn- error [text]
+  (str "\u001B[31m* ERROR: " text "\u001B[0m"))
+
+(defn- usage-error [{:keys [spec type cause msg option opts] :as data}]
+  (case type
+    :clj-watson/cli
+    (println (error msg))
+
+    :org.babashka/cli
+    (let [error-desc (cause {:require "Missing required argument"
+                             :validate "Invalid value for argument"
+                             :coerce "Cannot coerce value for argument"
+                             :restrict "Unrecognized argument"})
+          ;; show our custom validation messages
+          msg (when (and (= :validate cause)
+                         (some-> spec option :validate :ex-msg))
+                msg)]
+      (if (= :restrict cause)
+        (println (error (format "%s: %s" error-desc option)))
+        (let [arg-desc (format-opts {:spec (select-keys spec [option])
+                                     :opts opts})]
+          (println (error (format "%s:%s\n%s" error-desc
+                                  (if msg (str " " msg) "")
+                                  arg-desc))))))
+
+    (throw (ex-info msg data)))
+  (println)
+  (usage-help data)
+  (System/exit 1))
+
+(defn- opts->args [m]
+  (->> m
+       (reduce (fn [acc [k v]]
+                 (if (vector? v)
+                   (apply conj acc (interleave (repeat k) v))
+                   (conj acc k v)))
+               [])
+       (mapv pr-str)))
+
+(defn parse-args [args]
+  ;; can entertain moving to bb cli dispatch when we have more than one command
+  (let [orig-args args
+        {:keys [args opts]} (cli/parse-args args {:spec (select-keys spec-scan-args [:help :usage-help-style]) })]
+    (cond
+      (:help opts)
+      (do
+        (usage-help {:opts opts})
+        (System/exit 0))
+
+      (not= ["scan"] args)
+      (usage-error {:type :clj-watson/cli
+                    :msg (format "Invalid command, the only valid command is scan, detected: %s" (str/join ", " args))
+                    :spec spec-scan-args
+                    :opts opts})
+      :else
+      (cli/parse-opts orig-args {:spec spec-scan-args :error-fn usage-error :restrict true}))))
+
+(defn validate-tool-opts [opts]
+  (->> opts
+       opts->args
+       (into ["scan" ":usage-help-style" ":clojure-tool"])
+       parse-args))

--- a/src/clj_watson/cli_spec.clj
+++ b/src/clj_watson/cli_spec.clj
@@ -91,8 +91,8 @@
 
 (defn- cell-widths [rows]
   (reduce
-    (fn [widths row]
-      (map max (map count row) widths)) (repeat 0) rows))
+   (fn [widths row]
+     (map max (map count row) widths)) (repeat 0) rows))
 
 (defn- pad-cells
   "Adapted from bb cli"
@@ -233,7 +233,7 @@
 (defn parse-args [args]
   ;; can entertain moving to bb cli dispatch when we have more than one command
   (let [orig-args args
-        {:keys [args opts]} (cli/parse-args args {:spec (select-keys spec-scan-args [:help :usage-help-style]) })]
+        {:keys [args opts]} (cli/parse-args args {:spec (select-keys spec-scan-args [:help :usage-help-style])})]
     (cond
       (:help opts)
       (do

--- a/src/clj_watson/cli_spec.clj
+++ b/src/clj_watson/cli_spec.clj
@@ -15,7 +15,8 @@
     :ref "<file>"
     :coerce :string
     :validate validate-file-exists
-    :require true
+    :require :yes ;; Normally would `:require true` but clj-holmes\clj-holmes thinks this is a clojure spec
+                  ;; and raises: "Typo on schema declaration using :require instead of :required."
     :desc "Path of deps.edn file to scan"}
 
    :output

--- a/src/clj_watson/controller/output.clj
+++ b/src/clj_watson/controller/output.clj
@@ -6,7 +6,7 @@
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]))
 
-(defmulti ^:private generate* (fn [_ _ kind] (keyword kind)))
+(defmulti ^:private generate* (fn [_ _ kind] kind))
 
 (defmethod ^:private generate* :stdout-simple [dependencies & _]
   (let [template (-> "simple-report.mustache" io/resource slurp)]


### PR DESCRIPTION
When running via -X or -T:
- args are now validated
- benefits from rich bb cli coercion support
- usage help shows using keyword :arg syntax

When running via -M:
- preserved existing behaviour
- support more coercions
- usage help shows using cli -arg syntax

General:
- Narrower, easier to read usage help
- Options relating only to dependency-check strategy are now grouped under their own heading
- Some rewording/rewriting of descriptions for clarity
- Command line error styled in red for visibility
- Support for aligning multi-line argument descriptions
- File options fail fast if file does not exist
- More coercions to keywords happen at command parse time instead of within code. Code adjusted appropriately.

Closes #77