### PR TITLE
Review deps.edn

### DIFF
--- a/.clj-kondo/potemkin/potemkin/config.edn
+++ b/.clj-kondo/potemkin/potemkin/config.edn
@@ -1,0 +1,62 @@
+{:lint-as {potemkin.collections/compile-if      clojure.core/if
+           potemkin.collections/reify-map-type  clojure.core/reify
+           potemkin.collections/def-map-type    clj-kondo.lint-as/def-catch-all
+           potemkin.collections/def-derived-map clj-kondo.lint-as/def-catch-all
+
+           potemkin.types/reify+                clojure.core/reify
+           potemkin.types/defprotocol+          clojure.core/defprotocol
+           potemkin.types/deftype+              clojure.core/deftype
+           potemkin.types/defrecord+            clojure.core/defrecord
+           potemkin.types/definterface+         clojure.core/defprotocol
+           potemkin.types/extend-protocol+      clojure.core/extend-protocol
+           potemkin.types/def-abstract-type     clj-kondo.lint-as/def-catch-all
+
+           potemkin.utils/doit                  clojure.core/doseq
+           potemkin.utils/doary                 clojure.core/doseq
+           potemkin.utils/condp-case            clojure.core/condp
+           potemkin.utils/fast-bound-fn         clojure.core/bound-fn
+
+           potemkin.walk/prewalk                clojure.walk/prewalk
+           potemkin.walk/postwalk               clojure.walk/postwalk
+           potemkin.walk/walk                   clojure.walk/walk
+
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+           ;;;; top-level from import-vars
+           ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+           ;; Have hooks
+           ;;potemkin/import-fn potemkin.namespaces/import-fn
+           ;;potemkin/import-macro potemkin.namespaces/import-macro
+           ;;potemkin/import-def potemkin.namespaces/import-def
+
+           ;; Internal, not transitive
+           ;;potemkin/unify-gensyms               potemkin.macros/unify-gensyms
+           ;;potemkin/normalize-gensyms           potemkin.macros/normalize-gensyms
+           ;;potemkin/equivalent?                 potemkin.macros/equivalent?
+
+           potemkin/condp-case                  clojure.core/condp
+           potemkin/doit                        potemkin.utils/doit
+           potemkin/doary                       potemkin.utils/doary
+
+           potemkin/def-abstract-type           clj-kondo.lint-as/def-catch-all
+           potemkin/reify+                      clojure.core/reify
+           potemkin/defprotocol+                clojure.core/defprotocol
+           potemkin/deftype+                    clojure.core/deftype
+           potemkin/defrecord+                  clojure.core/defrecord
+           potemkin/definterface+               clojure.core/defprotocol
+           potemkin/extend-protocol+            clojure.core/extend-protocol
+
+           potemkin/reify-map-type              clojure.core/reify
+           potemkin/def-derived-map             clj-kondo.lint-as/def-catch-all
+           potemkin/def-map-type                clj-kondo.lint-as/def-catch-all}
+
+ ;; leave import-vars alone, kondo special-cases it
+ :hooks   {:macroexpand {#_#_potemkin.namespaces/import-vars potemkin.namespaces/import-vars
+                         potemkin.namespaces/import-fn    potemkin.namespaces/import-fn
+                         potemkin.namespaces/import-macro potemkin.namespaces/import-macro
+                         potemkin.namespaces/import-def   potemkin.namespaces/import-def
+
+                         #_#_potemkin/import-vars potemkin.namespaces/import-vars
+                         potemkin/import-fn               potemkin.namespaces/import-fn
+                         potemkin/import-macro            potemkin.namespaces/import-macro
+                         potemkin/import-def              potemkin.namespaces/import-def}}}

--- a/.clj-kondo/potemkin/potemkin/potemkin/namespaces.clj
+++ b/.clj-kondo/potemkin/potemkin/potemkin/namespaces.clj
@@ -1,0 +1,56 @@
+(ns potemkin.namespaces
+  (:require [clj-kondo.hooks-api :as api]))
+
+(defn import-macro*
+  ([sym]
+   `(def ~(-> sym name symbol) ~sym))
+  ([sym name]
+   `(def ~name ~sym)))
+
+(defmacro import-fn
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-macro
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+(defmacro import-def
+  ([sym]
+   (import-macro* sym))
+  ([sym name]
+   (import-macro* sym name)))
+
+#_
+(defmacro import-vars
+  "Imports a list of vars from other namespaces."
+  [& syms]
+  (let [unravel (fn unravel [x]
+                  (if (sequential? x)
+                    (->> x
+                         rest
+                         (mapcat unravel)
+                         (map
+                           #(symbol
+                              (str (first x)
+                                   (when-let [n (namespace %)]
+                                     (str "." n)))
+                              (name %))))
+                    [x]))
+        syms (mapcat unravel syms)
+        result `(do
+                  ~@(map
+                      (fn [sym]
+                        (let [vr (resolve sym)
+                              m (meta vr)]
+                          (cond
+                            (nil? vr) `(throw (ex-info (format "`%s` does not exist" '~sym) {}))
+                            (:macro m) `(def ~(-> sym name symbol) ~sym)
+                            (:arglists m) `(def ~(-> sym name symbol) ~sym)
+                            :else `(def ~(-> sym name symbol) ~sym))))
+                      syms))]
+    result))

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -25,9 +25,9 @@ jobs:
           java-version: ${{ matrix.jdk-version }}
 
       - name: Install clojure tools-deps
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@12.5
         with:
-          tools-deps: 1.11.1.1435
+          cli: 'latest'
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -35,6 +35,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-tests-${{ hashFiles('**/deps.edn') }}
           restore-keys: ${{ runner.os }}-m2-pr
+
+      - name: Tools versions
+        run: |
+          java --version
+          clojure --version
 
       - name: Execute ${{ matrix.namespace }} Test
         run: clojure -M:test ${{ matrix.namespace }}
@@ -58,9 +63,9 @@ jobs:
           java-version: '17'
 
       - name: Install clojure tools-deps
-        uses: DeLaGuardo/setup-clojure@master
+        uses: DeLaGuardo/setup-clojure@12.5
         with:
-          tools-deps: 1.11.1.1435
+          cli: 'latest'
 
       - name: Cache Maven packages
         uses: actions/cache@v4
@@ -68,6 +73,11 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-tests-${{ hashFiles('**/deps.edn') }}
           restore-keys: ${{ runner.os }}-m2
+
+      - name: Tools versions
+        run: |
+          java --version
+          clojure --version
 
       - name: Execute lint checks
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 * Unreleased
+  * Bump deps [#75](https://github.com/clj-holmes/clj-watson/issues/75)
   * Improve command line experience [#77](https://github.com/clj-holmes/clj-watson/issues/77)
 
 * v5.1.3 5812615 -- 2024-07-31

--- a/deps.edn
+++ b/deps.edn
@@ -1,38 +1,30 @@
-{:deps        {org.clojure/clojure                                     {:mvn/version "1.11.1"}
+{:deps        {org.clojure/clojure                                     {:mvn/version "1.11.4"}
                org.babashka/cli                                        {:mvn/version "0.8.60"}
-               borkdude/edamame                                        {:mvn/version "1.3.23"}
-               cheshire/cheshire                                       {:mvn/version "5.12.0"}
-               clj-http/clj-http                                       {:mvn/version "3.12.3"}
+               borkdude/edamame                                        {:mvn/version "1.4.25"}
+               cheshire/cheshire                                       {:mvn/version "5.13.0"}
+               clj-http/clj-http                                       {:mvn/version "3.13.0"}
                clj-time/clj-time                                       {:mvn/version "0.15.2"}
-               org.apache.maven.resolver/maven-resolver-transport-http {:mvn/version "1.9.18"}
-               org.clojure/tools.deps                                  {:mvn/version "0.18.1398"}
+               org.clojure/tools.deps                                  {:mvn/version "0.19.1432"}
                org.owasp/dependency-check-core                         {:mvn/version "10.0.3"}
                org.slf4j/slf4j-api                                     {:mvn/version "2.0.13"}
                ch.qos.logback/logback-classic                          {:mvn/version "1.5.6"}
                org.apache.logging.log4j/log4j-to-slf4j                 {:mvn/version "2.23.1"}
-               selmer/selmer                                           {:mvn/version "1.12.59"}
+               selmer/selmer                                           {:mvn/version "1.12.61"}
                version-clj/version-clj                                 {:mvn/version "2.0.2"}}
-
- :mvn/repos   {"central" {:url "https://repo1.maven.org/maven2/"}
-               "clojars" {:url "https://repo.clojars.org/"}}
 
  :paths       ["src" "resources"]
 
  :tools/usage {:ns-default clj-watson.entrypoint}
 
- :aliases     {:nREPL       {:extra-deps {nrepl/nrepl {:mvn/version "1.1.0"}}}
+ :aliases     {:nREPL       {:extra-deps {nrepl/nrepl {:mvn/version "1.2.0"}}}
                :outdated    {:deps {com.github.liquidz/antq {:mvn/version "2.8.1206"}
                                     org.slf4j/slf4j-simple {:mvn/version "2.0.13"}} ;; to rid ourselves of logger warnings
                              :main-opts ["-m" "antq.core"]}
                :clojure-lsp {:replace-deps {com.github.clojure-lsp/clojure-lsp-standalone
-                                            {:mvn/version "2023.12.29-12.09.27"}}
+                                            {:mvn/version "2024.04.22-11.50.26"}}
                              :main-opts    ["-m" "clojure-lsp.main"]}
                :test        {:extra-paths ["test"]
-                             :extra-deps
-                             {org.clojure/test.check {:mvn/version "1.1.1"}
-                              lambdaisland/kaocha    {:mvn/version "1.87.1366"}
-                              nubank/mockfn          {:mvn/version "0.7.0"}
-                              nubank/state-flow      {:mvn/version "5.14.5"}}
+                             :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
                              :main-opts   ["-m" "kaocha.runner"]}
 
                ;; for dev: so we can run the recommended command from the README:

--- a/src/clj_watson/entrypoint.clj
+++ b/src/clj_watson/entrypoint.clj
@@ -54,6 +54,7 @@
       (System/exit 1)
       (System/exit 0))))
 
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn scan
   "Direct entrypoint for -X & -T usage."
   [opts]


### PR DESCRIPTION
CI setup-clojure action
- moved action to current release instead of @master
- renamed deprecated `tools-deps` input to `cli`
- move to clojure version 'latest' (just like we do for each major JDK version)

CI
- report tools' versions to allow for reproducibility

clj-watson simple safe-looking bumps:
- clojure
- edamame
- cheshire
- clj-http
- tools.deps (has not changed much)
- selmer

clj-watson less safe-looking:
- org.apache.maven.resolver/maven-resolver-transport-http (deleted) - this dep is automatically included by tools.deps, and clj-watson does not reference it directly, and I don't see a rationale in git history for why we need to override the transitive version. It might have been a CVE or bug sometime in the past, let's see if we still actually need it.

Dev only:
- nrepl
- clojure-lsp-standalone
  - also suppressed unused public var for scan entrypoint
  - committed new .clj-kondo lib exports
- kaocha
- test-check (deleted, unused)
- state-flow (deleted, unused)
- mockfn (delete, unused)

Other deps.edn changes:
- delete `:mvn/repos` entry as it is no different from defaults

Closes #75