### PR TITLE
Explicitly close dependency-check engine when done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Unreleased
   * Improve command line experience [#77](https://github.com/clj-holmes/clj-watson/issues/77)
+  * Explicitly close the dependency-check engine when we are done with it [#86](https://github.com/clj-holmes/clj-watson/issues/86)
 
 * v5.1.3 5812615 -- 2024-07-31
   * Address [#60](https://github.com/clj-holmes/clj-watson/issues/60) by updating `org.owasp/dependency-check-core` to 10.0.3.

--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -12,7 +12,8 @@
   (binding [*out* *err*]
     (println "Downloading/Updating database.")
     (.doUpdates engine)
-    (println "Download/Update completed.")))
+    (println "Download/Update completed."))
+  engine)
 
 (defn- sanitize-property
   "Given a line from a properties file, remove sensitive information."
@@ -70,11 +71,14 @@
        (filter clojure-file?)
        (map io/file)
        (.scan engine))
-  (.analyzeDependencies engine))
+  (.analyzeDependencies engine)
+  engine)
 
 (defn start!
   [dependencies dependency-check-properties clj-watson-properties]
   (with-open [engine (build-engine dependency-check-properties clj-watson-properties)]
-    (update-download-database engine)
-    (scan-jars engine dependencies)
-    (->> engine .getDependencies Arrays/asList)))
+    (-> engine
+        (update-download-database)
+        (scan-jars dependencies)
+        (.getDependencies)
+        (Arrays/asList))))


### PR DESCRIPTION
Restructured internal code slightly to match semantics of working with a resource that is open then closed.

Closes #86