### PR TITLE
Respect dependency-check `odc.autoupdate` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Bump deps [#75](https://github.com/clj-holmes/clj-watson/issues/75)
   * Improve command line experience [#77](https://github.com/clj-holmes/clj-watson/issues/77)
   * Explicitly close the dependency-check engine when we are done with it [#86](https://github.com/clj-holmes/clj-watson/issues/86)
+  * Respect dependency-check `odc.autoupdate` property [#88](https://github.com/clj-holmes/clj-watson/issues/88)
 
 * v5.1.3 5812615 -- 2024-07-31
   * Address [#60](https://github.com/clj-holmes/clj-watson/issues/60) by updating `org.owasp/dependency-check-core` to 10.0.3.

--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -8,13 +8,6 @@
    (org.owasp.dependencycheck Engine)
    (org.owasp.dependencycheck.utils Settings)))
 
-(defn ^:private update-download-database [engine]
-  (binding [*out* *err*]
-    (println "Downloading/Updating database.")
-    (.doUpdates engine)
-    (println "Download/Update completed."))
-  engine)
-
 (defn- sanitize-property
   "Given a line from a properties file, remove sensitive information."
   [line]
@@ -78,7 +71,6 @@
   [dependencies dependency-check-properties clj-watson-properties]
   (with-open [engine (build-engine dependency-check-properties clj-watson-properties)]
     (-> engine
-        (update-download-database)
         (scan-jars dependencies)
         (.getDependencies)
         (Arrays/asList))))


### PR DESCRIPTION
Remove clj-watson's update of the nvd database.

Whether or not to update the nvd database is a dependency-check concern and controlled by the `dependency-check.properties` `odc.autoupdate` property.

Closes #88