### PR TITLE
Replace deprecated clj-time dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Improve command line experience [#77](https://github.com/clj-holmes/clj-watson/issues/77)
   * Explicitly close the dependency-check engine when we are done with it [#86](https://github.com/clj-holmes/clj-watson/issues/86)
   * Respect dependency-check `odc.autoupdate` property [#88](https://github.com/clj-holmes/clj-watson/issues/88)
+  * Replace deprecated clj-time dep with JDK8 java.time interop [#83](https://github.com/clj-holmes/clj-watson/issues/83)
 
 * v5.1.3 5812615 -- 2024-07-31
   * Address [#60](https://github.com/clj-holmes/clj-watson/issues/60) by updating `org.owasp/dependency-check-core` to 10.0.3.

--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,6 @@
                borkdude/edamame                                        {:mvn/version "1.4.25"}
                cheshire/cheshire                                       {:mvn/version "5.13.0"}
                clj-http/clj-http                                       {:mvn/version "3.13.0"}
-               clj-time/clj-time                                       {:mvn/version "0.15.2"}
                org.clojure/tools.deps                                  {:mvn/version "0.19.1432"}
                org.owasp/dependency-check-core                         {:mvn/version "10.0.3"}
                org.slf4j/slf4j-api                                     {:mvn/version "2.0.13"}

--- a/src/clj_watson/adapter/config.clj
+++ b/src/clj_watson/adapter/config.clj
@@ -1,12 +1,12 @@
 (ns clj-watson.adapter.config
-  (:require
-   [clj-time.format :as time.format]))
-
-(def time-parser (time.format/formatters :date))
+  (:import
+   (java.time LocalDate ZoneOffset)))
 
 (defn ->allow-config
   [{:keys [cve-label expires]}]
-  {cve-label (time.format/parse time-parser expires)})
+  {cve-label
+   ;; yyyy-MM-dd
+   (.atStartOfDay (LocalDate/parse expires) ZoneOffset/UTC)})
 
 (defn config->allow-config-map
   [config]

--- a/src/clj_watson/controller/github/vulnerability.clj
+++ b/src/clj_watson/controller/github/vulnerability.clj
@@ -1,10 +1,11 @@
 (ns clj-watson.controller.github.vulnerability
   (:require
-   [clj-time.core :as time]
    [clj-watson.diplomat.dependency :as diplomat.dependency]
    [clj-watson.diplomat.github.advisory :as diplomat.gh.advisory]
    [clj-watson.logic.github.vulnerability :as logic.gh.vulnerability]
-   [clj-watson.logic.rules.allowlist :as logic.rules.allowlist]))
+   [clj-watson.logic.rules.allowlist :as logic.rules.allowlist])
+  (:import
+   (java.time ZoneOffset ZonedDateTime)))
 
 (def ^:private dependency-rename
   {'org.jdom/jdom2 'org.jdom/jdom})
@@ -22,7 +23,7 @@
         all-dependency-vulnerabilities (diplomat.gh.advisory/vulnerabilities-by-package dependency-name-for-github)
         reported-vulnerabilities (filterv (partial logic.gh.vulnerability/is-version-vulnerable? dependency-info) all-dependency-vulnerabilities)
         ; not sure how to use it here and avoid always recommend the latest version (logic.gh.vulnerability/version-not-vulnerable all-dependency-vulnerabilities)
-        filtered-vulnerabilities (remove (partial logic.rules.allowlist/by-pass? allow-list (time/now)) reported-vulnerabilities)
+        filtered-vulnerabilities (remove (partial logic.rules.allowlist/by-pass? allow-list (ZonedDateTime/now ZoneOffset/UTC)) reported-vulnerabilities)
         latest-secure-version (latest-dependency-version dependency all-dependency-vulnerabilities repositories)]
     (if (seq filtered-vulnerabilities)
       (assoc dependency-info :vulnerabilities filtered-vulnerabilities :secure-version latest-secure-version)

--- a/src/clj_watson/logic/rules/allowlist.clj
+++ b/src/clj_watson/logic/rules/allowlist.clj
@@ -1,13 +1,11 @@
-(ns clj-watson.logic.rules.allowlist
-  (:require
-   [clj-time.core :as time]))
+(ns clj-watson.logic.rules.allowlist)
 
 (defn not-expired-bypass?
   ([allowed-cves as-of]
    (partial not-expired-bypass? allowed-cves as-of))
   ([allowed-cves as-of {identifier :value}]
    (when-let [expire-date (get allowed-cves identifier)]
-     (time/after? expire-date as-of))))
+     (.isAfter expire-date as-of))))
 
 (defn by-pass?
   [allowed-cves

--- a/test/clj_watson/unit/adapter/config_test.clj
+++ b/test/clj_watson/unit/adapter/config_test.clj
@@ -1,19 +1,21 @@
 (ns clj-watson.unit.adapter.config-test
   (:require
-   [clj-time.core :as time]
    [clj-watson.adapter.config :as adapter.config]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all])
+  (:import
+   (java.time ZonedDateTime)
+   (java.time.format DateTimeParseException)))
 
 (deftest ->allow-config
   (testing "Allow Parsing"
-    (is (= {"CVE-1234" (time/date-time 2021 5 12)}
+    (is (= {"CVE-1234" (ZonedDateTime/parse "2021-05-12T00:00:00Z")}
            (adapter.config/->allow-config {:cve-label "CVE-1234" :expires "2021-05-12"})))
-    (is (thrown? IllegalArgumentException
+    (is (thrown? DateTimeParseException
                  (adapter.config/->allow-config {:cve-label "CVE-1234" :expires "wrong date"})))))
 
 (deftest config->allow-list
   (testing "Configs Parsing"
-    (is (= {"CVE-1234" (time/date-time 2021 5 12)
-            "CVE-5678" (time/date-time 2025 5 12)}
+    (is (= {"CVE-1234" (ZonedDateTime/parse "2021-05-12T00:00:00Z")
+            "CVE-5678" (ZonedDateTime/parse "2025-05-12T00:00:00Z")}
            (adapter.config/config->allow-config-map {:allow-list {:cves [{:cve-label "CVE-1234" :expires "2021-05-12"}
                                                                          {:cve-label "CVE-5678" :expires "2025-05-12"}]}})))))

--- a/test/clj_watson/unit/logic/rules/allowlist_test.clj
+++ b/test/clj_watson/unit/logic/rules/allowlist_test.clj
@@ -1,12 +1,13 @@
 (ns clj-watson.unit.logic.rules.allowlist-test
   (:require
-   [clj-time.core :as time]
    [clj-watson.logic.rules.allowlist :as logic.rules.allowlist]
-   [clojure.test :refer :all]))
+   [clojure.test :refer :all])
+  (:import
+   (java.time ZonedDateTime)))
 
-(def expired-as-of (time/date-time 2023 3 3))
-(def as-of (time/date-time 2024 4 4))
-(def valid-as-of (time/date-time 2025 5 5))
+(def expired-as-of (ZonedDateTime/parse "2023-03-03T00:00:00Z")) ;; always from yyyy-MM-dd
+(def as-of (ZonedDateTime/parse "2024-04-04T11:42:17Z"))         ;; clj-watson usage is as of now
+(def valid-as-of (ZonedDateTime/parse "2025-05-05T00:00:00Z"))   ;; always from yyyy-MM-dd
 
 (deftest empty-bypass?
   (is (nil?


### PR DESCRIPTION
Replaced with JDK8 java.time interop.

Retained treating date/times as UTC.

Closes #83