### PR TITLE
Show score & severity in dependency-check findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 * Unreleased
+  * Fix: show score and severity in dependency-check findings [#58](https://github.com/clj-holmes/clj-watson/issues/58)
   * Bump deps [#75](https://github.com/clj-holmes/clj-watson/issues/75)
   * Improve command line experience [#77](https://github.com/clj-holmes/clj-watson/issues/77)
   * Explicitly close the dependency-check engine when we are done with it [#86](https://github.com/clj-holmes/clj-watson/issues/86)

--- a/src/clj_watson/logic/dependency_check/vulnerability.clj
+++ b/src/clj_watson/logic/dependency_check/vulnerability.clj
@@ -6,13 +6,13 @@
 
 (defn ^:private cvssv3 [vulnerability]
   (try
-    (some-> vulnerability .getCvssV3 .getBaseScore)
+    (some-> vulnerability .getCvssV3 .getCvssData .getBaseScore)
     (catch Exception _
       nil)))
 
 (defn ^:private severity [vulnerability]
   (try
-    (some-> vulnerability .getCvssV3 .getBaseSeverity)
+    (some-> vulnerability .getCvssV3 .getCvssData .getBaseSeverity str)
     (catch Exception _
       nil)))
 


### PR DESCRIPTION
Adapt to a breaking change in the dependency-check API.

Thanks to @chrisetheridge for the issue & fix!

Closes #58