### PR TITLE
Console logging should go to stderr

### DIFF
--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,5 +1,6 @@
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
     <encoder>
       <pattern>%d %highlight(%level) %logger{0} - %msg%n</pattern>
     </encoder>


### PR DESCRIPTION
Users need a way to separate logging output from println output.