### PR TITLE
Fix rendering of JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+* Unreleased
+  * Fix: `--output json` now renders correctly & JSON output now pretty-printed [#116](https://github.com/clj-holmes/clj-watson/issues/116)
+
 * v6.0.0 cb02879 -- 2024-08-20
   * Fix: show score and severity in dependency-check findings [#58](https://github.com/clj-holmes/clj-watson/issues/58)
   * Bump deps [#75](https://github.com/clj-holmes/clj-watson/issues/75)

--- a/src/clj_watson/controller/output.clj
+++ b/src/clj_watson/controller/output.clj
@@ -17,13 +17,13 @@
     (println (logic.template/generate {:vulnerable-dependencies dependencies} template))))
 
 (defmethod ^:private generate* :json [dependencies & _]
-  (-> dependencies json/generate-string pprint/pprint))
+  (-> dependencies (json/generate-string {:pretty true}) println))
 
 (defmethod ^:private generate* :edn [dependencies & _]
   (pprint/pprint dependencies))
 
 (defmethod ^:private generate* :sarif [dependencies deps-edn-path & _]
-  (-> dependencies (logic.sarif/generate deps-edn-path) json/generate-string println))
+  (-> dependencies (logic.sarif/generate deps-edn-path) (json/generate-string {:pretty true}) println))
 
 (defn generate [dependencies deps-edn-path kind]
   (generate* dependencies deps-edn-path kind))


### PR DESCRIPTION
`json` output now renders as JSON.
`json` & `sarif` output (both are JSON) now pretty-printed.

Closes #116