### PR TITLE
Show short summary of findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Unreleased
   * Fix: `--output json` now renders correctly & JSON output now pretty-printed [#116](https://github.com/clj-holmes/clj-watson/issues/116)
   * Recognize CVSS2 and CVSS4 scores when available [#112](https://github.com/clj-holmes/clj-watson/issues/112)
+  * Show short summary of findings [#87](https://github.com/clj-holmes/clj-watson/issues/87)
 
 * v6.0.0 cb02879 -- 2024-08-20
   * Fix: show score and severity in dependency-check findings [#58](https://github.com/clj-holmes/clj-watson/issues/58)

--- a/deps.edn
+++ b/deps.edn
@@ -25,7 +25,7 @@
                              :main-opts    ["-m" "clojure-lsp.main"]}
                :test        {:extra-paths ["test"]
                              :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
-                             :main-opts   ["-m" "kaocha.runner"]}
+                             :main-opts   ["-m" "kaocha.runner" "--reporter" "documentation"]}
 
                ;; for dev: so we can run the recommended command from the README:
                :clj-watson {:replace-deps {io.github.clj-holmes/clj-watson {:local/root "."}}

--- a/src/clj_watson/controller/github/vulnerability.clj
+++ b/src/clj_watson/controller/github/vulnerability.clj
@@ -59,9 +59,10 @@
 
 (defn scan-dependencies
   [dependencies repositories allow-list]
-  (->> dependencies
-       (pmap (partial scan-dependency repositories allow-list))
-       (filterv :vulnerabilities)))
+  {:deps-scanned (count dependencies)
+   :findings (->> dependencies
+                  (pmap (partial scan-dependency repositories allow-list))
+                  (filterv :vulnerabilities))})
 
 (comment
   (def repositories {:mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}

--- a/src/clj_watson/controller/output.clj
+++ b/src/clj_watson/controller/output.clj
@@ -4,7 +4,8 @@
    [clj-watson.logic.sarif :as logic.sarif]
    [clj-watson.logic.template :as logic.template]
    [clojure.java.io :as io]
-   [clojure.pprint :as pprint]))
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]))
 
 (defmulti ^:private generate* (fn [_ _ kind] kind))
 
@@ -27,3 +28,29 @@
 
 (defn generate [dependencies deps-edn-path kind]
   (generate* dependencies deps-edn-path kind))
+
+(defn final-summary
+  "See `clj-waston.logic.summarize/summary` for description"
+  [{:keys [cnt-deps-scanned cnt-deps-vulnerable
+           cnt-deps-severities cnt-deps-unexpected-severities cnt-deps-unspecified-severity]}]
+  (let [details (->> [(when (seq cnt-deps-severities)
+                        (format "(%s)"
+                                (->> cnt-deps-severities
+                                     (mapv (fn [[severity count]] (format "%d %s" count severity)))
+                                     (str/join ", "))))
+                      (when (seq cnt-deps-unexpected-severities)
+                        (format "Unrecognized severities: (%s)"
+                                (->> cnt-deps-unexpected-severities
+                                     (mapv (fn [[severity count]] (format "%d %s" count severity)))
+                                     (str/join ", "))))
+                      (when (and cnt-deps-unspecified-severity (> cnt-deps-unspecified-severity 0))
+                        (format "Unspecified severities: %d" cnt-deps-unspecified-severity))]
+                     (keep identity))]
+    ;; Dependencies scanned: 151
+    ;; Vulnerable dependencies found: 9 (4 Critical, 1 High, 2 Medium), Unrecognize d severities: (2 Foobar), Unspecified severities: 3
+    (println (format "Dependencies scanned: %d" cnt-deps-scanned))
+    (println (format "Vulnerable dependencies found: %d%s"
+                     cnt-deps-vulnerable
+                     (if (seq details)
+                       (str " " (str/join ", " details))
+                       "")))))

--- a/src/clj_watson/logging_config.clj
+++ b/src/clj_watson/logging_config.clj
@@ -34,6 +34,8 @@
 (defn init
   "Complement `resources/logaback.xml` with some customizations"
   []
+  ;; dependency-check uses Apache Commons JCS, ask it to use log4j2 to allow us to configure its noisy logging
+  (System/setProperty "jcs.logSystem" "log4j2")
   (.addTurboFilter (LoggerFactory/getILoggerFactory) (create-custom-filter)))
 
 (comment


### PR DESCRIPTION
Include a 2-line summary of findings that reports the number of dependencies scanned, vulnerabilities found, and vulnerabilities broken down by severity.

The break down by severity makes no effort to distinguish between CVSS2, CVSS3 and CVSS4 scores. For example, CVSS2 has no Critical severity, so a High CVSS2 could be classified as a Critical CVSS3/CVSS4. For a summary, I think this is fine.

Accounts for possibility that data might have unspecified or unrecognized severity values. I think this is less likely for dependency-check (at least today as I've looked at the downloaded db), but have less of an idea of what values github-advisory might return.

Some minor cleanups in touched code:
- de-duplicated shared scan logic in entrypoint ns
- moved logging setup to logging-config ns
- change kaocha test reporter to show tests being run

Closes #87