### PR TITLE
Add `--cvss-fail-threshold`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 * Unreleased
+  * Add `--cvss-fail-threshold` to fail when a vulnerability meets or exceeds a given CVSS score [#114](https://github.com/clj-holmes/clj-watson/issues/114)
   * Fix: `--output json` now renders correctly & JSON output now pretty-printed [#116](https://github.com/clj-holmes/clj-watson/issues/116)
   * Recognize CVSS2 and CVSS4 scores when available [#112](https://github.com/clj-holmes/clj-watson/issues/112)
   * Show short summary of findings [#87](https://github.com/clj-holmes/clj-watson/issues/87)

--- a/src/clj_watson/cli_spec.clj
+++ b/src/clj_watson/cli_spec.clj
@@ -246,7 +246,7 @@
       (let [opts (cli/parse-opts orig-args {:spec spec-scan-args :error-fn usage-error :restrict true})]
         (if (and (:cvss-fail-threshold opts) (:fail-on-result opts))
           (usage-error {:type :clj-watson/cli
-                        :msg (format "Invalid usage, specificy only one of: %s"
+                        :msg (format "Invalid usage, specify only one of: %s"
                                      (->> [:fail-on-result :cvss-fail-threshold]
                                           (mapv #(styled-long-opt % opts))
                                           (str/join ", ")))

--- a/src/clj_watson/controller/output.clj
+++ b/src/clj_watson/controller/output.clj
@@ -2,6 +2,7 @@
   (:require
    [cheshire.core :as json]
    [clj-watson.logic.sarif :as logic.sarif]
+   [clj-watson.logic.table :as table]
    [clj-watson.logic.template :as logic.template]
    [clojure.java.io :as io]
    [clojure.pprint :as pprint]
@@ -54,3 +55,53 @@
                      (if (seq details)
                        (str " " (str/join ", " details))
                        "")))))
+
+(defn- cvss-threshold-summary->rows [opts data]
+  {:rows
+   (into [(mapv #(:title %) opts)]
+         (mapv (fn [s]
+                 (mapv (fn [{:keys [key]}]
+                         (-> s key str))
+                       opts))
+               data))})
+
+(defn cvss-threshold-summary [{:keys [threshold scores-met]}]
+  ;; CVSS fail score threshold of 2.0 met for:
+  ;;
+  ;;  Dependency Version Identifiers CVSS Score
+  ;;  foo/bar    1.2.3   CVE-1231    5.2 (version 3.1)
+  ;;  foo/bar1   7.7a    CVE-123134  6.9 (score missing - derived from Medium severity)
+  ;;  foo/bar2   2.0     CVE-12313   10.0 (score missing - derived from High severity)
+  ;;  foo/bar3   24.2    CVE-188     10.0 (score missing - derived from Critical severity)
+  ;;  foo/bar4   8.2     CVE-123132  10.0 (score missing and severity Foo unrecognized)
+  ;;  foo/bar5   1.12    CVE-12313   10.0 (score and severity missing)
+  ;;  foo/bar6   1.12    CVE-1232    10.0 (score 0.0 suspicious and severity missing)
+  ;;  foo/bar6   1.12    CVE-1237    10.0 (score foo suspicious and severity missing)
+  ;;  foo/bar6   1.12    CVE-1238    10.0 (score 11.2 suspicious and severity missing)
+  (if-not (seq scores-met)
+    (println (format "No scores met CVSS fail threshold of %s" threshold))
+    (do
+      (println (format "CVSS fail score threshold of %s met for:\n" threshold))
+      (->> scores-met
+           (mapv (fn [{:keys [identifiers score severity score-version score-derivation suspicious-score suspicious-severity] :as m}]
+                   (assoc m
+                          :identifiers (str/join " " identifiers)
+                          :score-desc
+                          (format "%s (%s)"
+                                  score
+                                  (if-let [[score-analysis severity-analysis] score-derivation]
+                                    (format "%s %s"
+                                            (case score-analysis
+                                              :missing-score "score missing"
+                                              :suspicious-score (format "score %s suspicious" suspicious-score))
+                                            (case severity-analysis
+                                              :valid-severity (format "- derived from %s severity" severity)
+                                              :missing-severity "and severity missing"
+                                              :suspicious-severity (format "and severity %s unrecognized" suspicious-severity)))
+                                    (format "version %s" (or score-version "<missing>")))))))
+           (cvss-threshold-summary->rows [{:key :dependency  :title "Dependency"}
+                                          {:key :version     :title "Version"}
+                                          {:key :identifiers :title "Identifiers"}
+                                          {:key :score-desc  :title "CVSS Score"}])
+           table/format-table
+           println))))

--- a/src/clj_watson/logic/table.clj
+++ b/src/clj_watson/logic/table.clj
@@ -1,0 +1,68 @@
+(ns clj-watson.logic.table
+  "Most of this table support is stolen/adapted from babashka.cli"
+  (:require
+   [clojure.string :as str]))
+
+(defn- str-width
+  "Width of `s` when printed, i.e. without ANSI escape codes."
+  [s]
+  (let [strip-escape-codes #(str/replace %
+                                         (re-pattern "(\\x9B|\\x1B\\[)[0-?]*[ -\\/]*[@-~]") "")]
+    (count (strip-escape-codes s))))
+
+(defn- pad [len s] (str s (apply str (repeat (- len (str-width s)) " "))))
+
+(defn- pad-cells
+  "Adapted from bb cli"
+  [rows widths]
+  (let [pad-row (fn [row]
+                  (map (fn [width cell] (pad width cell)) widths row))]
+    (map pad-row rows)))
+
+(defn- expand-multilines
+  "Expand last column cell over multiple rows if it contains newlines"
+  [rows]
+  (reduce (fn [acc row]
+            (let [[line & extra-lines] (-> row last str/split-lines)
+                  cols (count row)]
+              (if (seq extra-lines)
+                (apply conj acc
+                       (assoc (into [] row) (dec cols) line)
+                       (map #(conj (into [] (repeat (dec cols) ""))
+                                   %)
+                            extra-lines))
+                (conj acc row))))
+          []
+          rows))
+
+(defn cell-widths [rows]
+  (reduce
+   (fn [widths row]
+     (map max (map str-width row) widths)) (repeat 0) rows))
+
+(defn format-table
+  "Modified from bb cli format-table. Allow pre-computed widths to be passed in."
+  [{:keys [rows indent widths] :or {indent 2}}]
+  (let [widths (or widths (cell-widths rows))
+        rows (expand-multilines rows)
+        rows (pad-cells rows widths)
+        fmt-row (fn [leader divider trailer row]
+                  (str leader
+                       (apply str (interpose divider row))
+                       trailer))]
+    (->> rows
+         (map (fn [row]
+                (fmt-row (apply str (repeat indent " ")) " " "" row)))
+         (map str/trimr)
+         (str/join "\n"))))
+
+(comment
+  (-> (format-table {:rows [["r1c1" "r1c2" "r1c3"]
+                            ["r2c1 wider" "r2c2" "r2c3"]
+                            ["r3c1" "r3c2 wider" "r3c3"]]})
+      str/split-lines)
+  ;; => ["  r1c1       r1c2       r1c3"
+  ;;     "  r2c1 wider r2c2       r2c3"
+  ;;     "  r3c1       r3c2 wider r3c3"]
+
+  :eoc)

--- a/src/clj_watson/logic/utils.clj
+++ b/src/clj_watson/logic/utils.clj
@@ -1,0 +1,11 @@
+(ns clj-watson.logic.utils)
+
+(defn assoc-some
+  "Associates a key with a value in a map, if and only if the value is
+  not nil. From medley."
+  ([m k v]
+   (if (nil? v) m (assoc m k v)))
+  ([m k v & kvs]
+   (reduce (fn [m [k v]] (assoc-some m k v))
+           (assoc-some m k v)
+           (partition 2 kvs))))

--- a/test/clj_watson/unit/controller/output_test.clj
+++ b/test/clj_watson/unit/controller/output_test.clj
@@ -3,13 +3,13 @@
    [clj-watson.controller.output :as output]
    [clojure.test :refer [deftest is]]))
 
-(deftest all-good-test
+(deftest final-summary-all-good-test
   (is (= (str "Dependencies scanned: 72\n"
               "Vulnerable dependencies found: 0\n")
          (with-out-str (output/final-summary {:cnt-deps-scanned 72
                                               :cnt-deps-vulnerable 0})))))
 
-(deftest expected-severities-test
+(deftest final-summary-expected-severities-test
   (is (= (str "Dependencies scanned: 72\n"
               "Vulnerable dependencies found: 10 (3 Critical, 2 High, 1 Medium, 4 Low)\n")
          (with-out-str (output/final-summary {:cnt-deps-scanned 72
@@ -19,7 +19,7 @@
                                                                     ["High" 2]
                                                                     ["Medium" 1]
                                                                     ["Low" 4]]})))))
-(deftest unexpected-and-unspecified-severities-test
+(deftest final-summary-unexpected-and-unspecified-severities-test
   (is (= (str "Dependencies scanned: 72\n"
               "Vulnerable dependencies found: 11 (7 Critical), Unrecognized severities: (2 Foo, 7 Bar), Unspecified severities: 7\n")
          (with-out-str (output/final-summary {:cnt-deps-scanned 72
@@ -27,3 +27,69 @@
                                               :cnt-deps-unspecified-severity 7
                                               :cnt-deps-unexpected-severities [["Foo" 2] ["Bar" 7]]
                                               :cnt-deps-severities [["Critical" 7]]})))))
+
+(deftest cvss-threshold-summary-all-good-test
+  (is (= "No scores met CVSS fail threshold of 2.2\n"
+         (with-out-str (output/cvss-threshold-summary {:threshold 2.2 :scores-met []})))))
+
+(deftest cvss-thresold-summary-test
+  (is (= "CVSS fail score threshold of 1.7 met for:
+
+  Dependency                           Version Identifiers CVSS Score
+  all/good                             1.2.3   id1         1.9 (version 4.0)
+  missing/version                      1.2.4   id2 id3     2.0 (version <missing>)
+  missing-score/severity-valid         3.3.3   id4         3.5 (score missing - derived from Low severity)
+  suspicious-score/severity-valid      2.2.2   id5         10.0 (score 0.0 suspicious - derived from High severity)
+  missing-score/severity-missing       2.2.3   id6         10.0 (score missing and severity missing)
+  suspicious-score/severity-missing    2.2.4   id7         10.0 (score 12.2 suspicious and severity missing)
+  missing-score/severity-suspicious    2.2.3   id8         10.0 (score missing and severity moodog unrecognized)
+  suspicious-score/severity-suspicious 2.2.4   id9         10.0 (score 12.2 suspicious and severity blarg unrecognized)
+"
+         (with-out-str (output/cvss-threshold-summary
+                        {:threshold 1.7 :scores-met
+                         [{:identifiers ["id1"]
+                           :dependency "all/good"
+                           :version "1.2.3"
+                           :score 1.9
+                           :score-version "4.0"}
+                          {:identifiers ["id2" "id3"]
+                           :dependency "missing/version"
+                           :version "1.2.4"
+                           :score 2.0}
+                          {:identifiers ["id4"]
+                           :dependency "missing-score/severity-valid"
+                           :version "3.3.3"
+                           :score 3.5 ;; we just present here, we don't derive
+                           :score-derivation [:missing-score :valid-severity]
+                           :severity "Low"}
+                          {:identifiers ["id5"]
+                           :dependency "suspicious-score/severity-valid"
+                           :version "2.2.2"
+                           :score 10.0
+                           :suspicious-score 0.0
+                           :score-derivation [:suspicious-score :valid-severity]
+                           :severity "High"}
+                          {:identifiers ["id6"]
+                           :dependency "missing-score/severity-missing"
+                           :version "2.2.3"
+                           :score 10.0
+                           :score-derivation [:missing-score :missing-severity]}
+                          {:identifiers ["id7"]
+                           :dependency "suspicious-score/severity-missing"
+                           :version "2.2.4"
+                           :score 10.0
+                           :suspicious-score 12.2
+                           :score-derivation [:suspicious-score :missing-severity]}
+                          {:identifiers ["id8"]
+                           :dependency "missing-score/severity-suspicious"
+                           :version "2.2.3"
+                           :score 10.0
+                           :suspicious-severity "moodog"
+                           :score-derivation [:missing-score :suspicious-severity]}
+                          {:identifiers ["id9"]
+                           :dependency "suspicious-score/severity-suspicious"
+                           :version "2.2.4"
+                           :score 10.0
+                           :suspicious-score 12.2
+                           :suspicious-severity "blarg"
+                           :score-derivation [:suspicious-score :suspicious-severity]}]})))))

--- a/test/clj_watson/unit/logic/summarize_test.clj
+++ b/test/clj_watson/unit/logic/summarize_test.clj
@@ -3,21 +3,21 @@
    [clj-watson.logic.summarize :as summarize]
    [clojure.test :refer [deftest is]]))
 
-(deftest all-good-test
+(deftest final-summary-all-good-test
   (is (= {:cnt-deps-scanned 42
           :cnt-deps-vulnerable 0
           :cnt-deps-severities []
           :cnt-deps-unexpected-severities []
           :cnt-deps-unspecified-severity 0}
-         (summarize/summarize {:deps-scanned 42 :findings []}))))
+         (summarize/final-summary {:deps-scanned 42 :findings []}))))
 
-(deftest expected-severities-test
+(deftest final-summary-expected-severities-test
   (is (= {:cnt-deps-scanned 97
           :cnt-deps-vulnerable 7
           :cnt-deps-severities [["Critical" 1] ["High" 3] ["Medium" 2] ["Low" 1]]
           :cnt-deps-unexpected-severities []
           :cnt-deps-unspecified-severity 0}
-         (summarize/summarize
+         (summarize/final-summary
           {:deps-scanned 97
            :findings [{:vulnerabilities [{:advisory {:severity "High"}}]}   ;; high wins
                       {:vulnerabilities [{:advisory {:severity "Wtf"}}
@@ -38,13 +38,13 @@
                                          {:advisory {:severity "Medium"}}]} ;; medium wins                  ]}
                       ]}))))
 
-(deftest unexpected-and-missing-severities-test
+(deftest final-summary-unexpected-and-missing-severities-test
   (is (= {:cnt-deps-scanned 7123
           :cnt-deps-vulnerable 10
           :cnt-deps-severities [["Critical" 1] ["High" 2] ["Medium" 1]]
           :cnt-deps-unexpected-severities [["Bar" 2] ["Foo" 1]]
           :cnt-deps-unspecified-severity 3}
-         (summarize/summarize
+         (summarize/final-summary
           {:deps-scanned 7123
            :findings [{:vulnerabilities [{:advisory {:severity "High"}}]}   ;; high wins
                       {:vulnerabilities [{:advisory {:severity "Wtf"}}
@@ -70,3 +70,129 @@
                                          {:advisory {:severity "Aba"}}
                                          {:advisory {:severity "Bar"   :cvss {:score 9.9}}} ;; bar wins
                                          {:advisory {:severity "Alpha" :cvss {:score 9.8}}}]}]}))))
+
+(deftest cvss-thresold-summary-test
+  (let [filler-advisories [{:advisory {:identifiers [{:value "cvec"}]
+                                       :cvss {:score 3.1 :version 2.0}}}
+                           {:advisory {:identifiers [{:value "cved"}]
+                                       :cvss {:score 3.2 :version 2.0}}}]
+        findings [{:dependency "zzz/with-score" :mvn/version "2.1.0"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :cvss {:score 7.7 :version 3.1}}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 7.7 :version 3.0}}}]}
+                  {:dependency "yyy/missing-score-missing-severity" :mvn/version "2.1.1"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}]   ;; loses due to sort ordering
+                                                 :cvss {:score 10.0 :version 3.0}}}]}
+                  {:dependency "xxx/suspicious-score-missing-severity" :mvn/version "2.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :cvss {:score 0.0 :version 2.0}}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 10.0 :version 3.0}}}]}
+                  {:dependency "www/suspicious-score-missing-severity2" :mvn/version "2.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :cvss {:score "not-a-score"}}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 10.0 :version 3.0}}}]}
+                  {:dependency "vvv/suspicious-score-low-severity" :mvn/version "3.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :severity "LOW"
+                                                 :cvss {:score 10.1}}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 3.9 :version 3.0}}}]}
+                  {:dependency "uuu/missing-score-medium-severity" :mvn/version "3.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :severity "MEDIUM"}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}]  ;; loses due to sort ordering
+                                                 :cvss {:score 6.9 :version 3.0}}}]}
+                  {:dependency "ttt/suspicious-score-high-severity" :mvn/version "3.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :severity "HIGH"
+                                                 :cvss {:score -12.3}}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 10.0 :version 3.0}}}]}
+                  {:dependency "sss/suspicious-score-critical-severity" :mvn/version "3.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :severity "CRITICAL"
+                                                 :cvss {:score "nope"}}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 10.0 :version 3.0}}}]}
+                  {:dependency "rrr/missing-score-suspicious-severity" :mvn/version "3.1.2"
+                   :vulnerabilities [{:advisory {:identifiers [{:value "cveb"}]
+                                                 :severity "not-a-severity"}} ;; expected winner
+                                     {:advisory {:identifiers [{:value "cvea"}] ;; loses due to sort ordering
+                                                 :cvss {:score 10.0 :version 3.0}}}]}]
+        findings (->> findings
+                      (mapv #(update % :vulnerabilities into filler-advisories))
+                      (mapv #(update % :vulnerabilities shuffle))
+                      shuffle)
+        expected-scores-met [{:dependency "vvv/suspicious-score-low-severity"
+                              :version "3.1.2"
+                              :identifiers ["cveb"]
+                              :score 3.9 ;; upper bound low for CVSS2/3/4
+                              :severity "Low"
+                              :suspicious-score 10.1
+                              :score-derivation [:suspicious-score :valid-severity]}
+                             {:dependency "uuu/missing-score-medium-severity"
+                              :version "3.1.2"
+                              :identifiers ["cveb"]
+                              :score 6.9 ;; upper bound medium for CVSS2/3/4
+                              :severity "Medium"
+                              :score-derivation [:missing-score :valid-severity]}
+                             {:dependency "zzz/with-score"
+                              :version "2.1.0"
+                              :identifiers ["cveb"]
+                              :score 7.7
+                              :score-version 3.1}
+                             {:dependency "rrr/missing-score-suspicious-severity"
+                              :version "3.1.2"
+                              :identifiers ["cveb"]
+                              :score 10.0
+                              :severity "not-a-severity"
+                              :suspicious-severity "not-a-severity"
+                              :score-derivation [:missing-score :suspicious-severity]}
+                             {:dependency "sss/suspicious-score-critical-severity"
+                              :version "3.1.2"
+                              :identifiers ["cveb"]
+                              :score 10.0 ;; upper bound critical (for CVSS3)
+                              :severity "Critical"
+                              :suspicious-score "nope"
+                              :score-derivation [:suspicious-score :valid-severity]}
+                             {:dependency "ttt/suspicious-score-high-severity"
+                              :version "3.1.2"
+                              :identifiers ["cveb"]
+                              :score 10.0 ;; upper bound high (for CVSS2)
+                              :severity "High"
+                              :suspicious-score -12.3
+                              :score-derivation [:suspicious-score :valid-severity]}
+                             {:dependency "www/suspicious-score-missing-severity2"
+                              :version "2.1.2"
+                              :identifiers ["cveb"]
+                              :score 10.0
+                              :suspicious-score "not-a-score"
+                              :score-derivation [:suspicious-score :missing-severity]}
+                             {:dependency "xxx/suspicious-score-missing-severity"
+                              :version "2.1.2"
+                              :identifiers ["cveb"]
+                              :score 10.0
+                              :score-version 2.0
+                              :suspicious-score 0.0
+                              :score-derivation [:suspicious-score :missing-severity]}
+                             {:dependency "yyy/missing-score-missing-severity"
+                              :version "2.1.1"
+                              :identifiers ["cveb"]
+                              :score 10.0
+                              :score-derivation [:missing-score :missing-severity]}]]
+    (is (= {:threshold 0.0
+            :scores-met expected-scores-met}
+           (summarize/cvss-threshold-summary 0.0 {:findings findings}))
+        "all scores met")
+    (is (= {:threshold 10
+            :scores-met (filterv #(>= (:score %) 10) expected-scores-met)}
+           (summarize/cvss-threshold-summary 10 {:findings findings}))
+        "some scores met")
+    (is (= {:threshold 10.1
+            :scores-met []}
+           (summarize/cvss-threshold-summary 10.1 {:findings findings}))
+        "no scores met")))


### PR DESCRIPTION
See README for general description.

New option is mutually exclusive to `--fail-on-result`; if both are specified, clj-watson fails fast with usage error and help.

Conservatively derives score when missing or suspicious looking:
- When severity is available, conservatively converts to score
- Since we don't know if if score is CVSS2 or CVSS3/4 derives, High and Critical to 10.0, Medium and Low are converted to upper bound of their ranges.
- The experimental github-advisory strategy seems to regularly populate score with `0.0` but with a valid looking severity; we treat a score of 0.0 as suspicious.
- I've not seen cases of invalid severities in the wild, but we handle them just the same, when we can't make sense of things we derive to the most critical score which is 10.0.

Also:
- factored out table support from cli-spec ns to new table ns to reuse it for summary table.
- renamed summarize fn to final-summary to better distinguish from our new summary fn
- a new utils ns for `assoc-some` fn (cribbed clj-kondo which cribbed from medley).

Closes #114