### PR TITLE
fix configuring DependencyCheck Downloader with settings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
                cheshire/cheshire                                       {:mvn/version "5.13.0"}
                clj-http/clj-http                                       {:mvn/version "3.13.0"}
                org.clojure/tools.deps                                  {:mvn/version "0.20.1440"}
-               org.owasp/dependency-check-core                         {:mvn/version "10.0.4"}
+               org.owasp/dependency-check-core                         {:mvn/version "12.1.0"}
                org.slf4j/slf4j-api                                     {:mvn/version "2.0.16"}
                ch.qos.logback/logback-classic                          {:mvn/version "1.5.7"}
                org.apache.logging.log4j/log4j-to-slf4j                 {:mvn/version "2.23.1"}

--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -8,7 +8,7 @@
    (java.io ByteArrayInputStream File)
    (java.util Arrays)
    (org.owasp.dependencycheck Engine)
-   (org.owasp.dependencycheck.utils Settings)))
+   (org.owasp.dependencycheck.utils Settings Downloader)))
 
 (defn- sanitize-property
   "Given a line from a properties file, remove sensitive information."
@@ -118,6 +118,7 @@
   (let [settings (create-settings dependency-check-properties clj-watson-properties)]
     (when-let [{:keys [exit]} (validate-settings settings opts)]
       (System/exit exit))
+    (.configure (Downloader/getInstance) settings)
     (let [jars (deps->jars dependencies)
           vulnerable-jars (with-open [engine (build-engine settings)]
                             (-> engine

--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -8,7 +8,7 @@
    (java.io ByteArrayInputStream File)
    (java.util Arrays)
    (org.owasp.dependencycheck Engine)
-   (org.owasp.dependencycheck.utils Settings Downloader)))
+   (org.owasp.dependencycheck.utils Downloader Settings)))
 
 (defn- sanitize-property
   "Given a line from a properties file, remove sensitive information."


### PR DESCRIPTION
# Description

When hosting a local cache created with [open-vulnerability-cli](https://github.com/jeremylong/open-vulnerability-cli), the scanning process will fail with the exception below.

The configuration of DependencyCheck is done through java properties:

```
nvd.api.datafeed.url=http://localhost:8000/nvdcve-{0}.json.gz
```

The cache.properties will be correctly fetched from the local cache, but downloading an actual gz file doesn't work.

Exception:

```
2025-02-21 15:41:48,534 INFO DownloadTask - Download Started for NVD Cache - http://localhost:8000/nvdcve-2015.json.gz
2025-02-21 15:41:48,535 ERROR DownloadTask - Error downloading NVD CVE - http://localhost:8000/nvdcve-2015.json.gz Reason: null
2025-02-21 15:41:48,535 ERROR Engine - The execution of the download was interrupted
org.owasp.dependencycheck.data.update.exception.UpdateException: The execution of the download was interrupted
        at org.owasp.dependencycheck.data.update.NvdApiDataSource.processDownload(NvdApiDataSource.java:283)
        at org.owasp.dependencycheck.data.update.NvdApiDataSource.processDatafeed(NvdApiDataSource.java:172)
        at org.owasp.dependencycheck.data.update.NvdApiDataSource.update(NvdApiDataSource.java:115)
        at org.owasp.dependencycheck.Engine.doUpdates(Engine.java:903)
        at org.owasp.dependencycheck.Engine.initializeAndUpdateDatabase(Engine.java:708)
        at org.owasp.dependencycheck.Engine.analyzeDependencies(Engine.java:634)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:184)
        at clojure.lang.Reflector.invokeNoArgInstanceMember(Reflector.java:455)
        at clj_watson.controller.dependency_check.scanner$scan_jars.invokeStatic(scanner.clj:113)
        at clj_watson.controller.dependency_check.scanner$scan_jars.invoke(scanner.clj:111)
        at clj_watson.controller.dependency_check.scanner$start_BANG_$fn__940.invoke(scanner.clj:124)
        at clj_watson.controller.dependency_check.scanner$start_BANG_.invokeStatic(scanner.clj:122)
        at clj_watson.controller.dependency_check.scanner$start_BANG_.invoke(scanner.clj:116)
        at clj_watson.entrypoint$eval9098$fn__9100.invoke(entrypoint.clj:26)
        at clojure.lang.MultiFn.invoke(MultiFn.java:229)
        at clj_watson.entrypoint$do_scan.invokeStatic(entrypoint.clj:39)
        at clj_watson.entrypoint$do_scan.invoke(entrypoint.clj:35)
        at clj_watson.cli$_main.invokeStatic(cli.clj:10)
        at clj_watson.cli$_main.doInvoke(cli.clj:7)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.core$apply.invokeStatic(core.clj:667)
        at clojure.main$main_opt.invokeStatic(main.clj:514)
        at clojure.main$main_opt.invoke(main.clj:510)
        at clojure.main$main.invokeStatic(main.clj:664)
        at clojure.main$main.doInvoke(main.clj:616)
        at clojure.lang.RestFn.applyTo(RestFn.java:137)
        at clojure.lang.Var.applyTo(Var.java:705)
        at clojure.main.main(main.java:40)
Caused by: java.util.concurrent.ExecutionException: java.lang.NullPointerException
        at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
        at org.owasp.dependencycheck.data.update.NvdApiDataSource.processDownload(NvdApiDataSource.java:273)
        ... 32 common frames omitted
Caused by: java.lang.NullPointerException: null
        at org.owasp.dependencycheck.utils.Downloader.fetchFile(Downloader.java:446)
        at org.owasp.dependencycheck.data.update.nvd.api.DownloadTask.call(DownloadTask.java:88)
        at org.owasp.dependencycheck.data.update.nvd.api.DownloadTask.call(DownloadTask.java:39)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

I logged an issue first in the DependencyCheck repo https://github.com/dependency-check/DependencyCheck/issues/7452, but it's expected to configure the Downloader instance from the tool that is calling into DependencyCheck core.

I added this configuration in the scanner initialization.

After this change downloading the files from a local cache works.