### PR TITLE
Correct typo in `--clj-watson-properties` usage message

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ OPTIONS:
 OPTIONS valid when database-strategy is dependency-check:
   -w, --clj-watson-properties <file>                         Path of an additional, optional properties file
                                                              Overrides values in dependency-check.properties
-                                                             If not specified classpath is searched for cljwatson.properties
+                                                             If not specified classpath is searched for clj-watson.properties
       --run-without-nvd-api-key                              Run without an nvd.api.key configured.
                                                              It will be slow and we cannot recommend it.
                                                              See docs for configuration. [false]

--- a/src/clj_watson/cli_spec.clj
+++ b/src/clj_watson/cli_spec.clj
@@ -97,7 +97,7 @@
     :validate validate-file-exists
     :desc (str "Path of an additional, optional properties file\n"
                "Overrides values in dependency-check.properties\n"
-               "If not specified classpath is searched for cljwatson.properties")}
+               "If not specified classpath is searched for clj-watson.properties")}
 
    :run-without-nvd-api-key
    {:type :flag


### PR DESCRIPTION
The default value is for `--clj-watson-properties` is `clj-watson.properties`.

See also commit c946fa8407d872719a0f / #99.