### PR TITLE
For -M usage, call shutdown-agents on natural exit

### DIFF
--- a/src/clj_watson/cli.clj
+++ b/src/clj_watson/cli.clj
@@ -11,5 +11,6 @@
   "Entrypoint for -M cli usage"
   [& args]
   (let [{:keys [exit]} (entrypoint/scan-main args)]
-    (when exit
-      (system-exit exit))))
+    (if exit
+      (system-exit exit)
+      (shutdown-agents))))

--- a/src/clj_watson/cli.clj
+++ b/src/clj_watson/cli.clj
@@ -11,6 +11,6 @@
   "Entrypoint for -M cli usage"
   [& args]
   (let [{:keys [exit]} (entrypoint/scan-main args)]
-    (if exit
-      (system-exit exit)
-      (shutdown-agents))))
+    (shutdown-agents)
+    (when exit
+      (system-exit exit))))


### PR DESCRIPTION
During testing I noticed that there was sometimes a long pause at exit for -M usage. Fix with a call to `shutdown-agents` on natural exit.

Addendum for #138