### PR TITLE
Mask sensitive properties on output

### DIFF
--- a/.clj-kondo/babashka/fs/config.edn
+++ b/.clj-kondo/babashka/fs/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {babashka.fs/with-temp-dir clojure.core/let}}

--- a/deps.edn
+++ b/deps.edn
@@ -25,9 +25,14 @@
                              :main-opts    ["-m" "clojure-lsp.main"]}
                :test        {:extra-paths ["test"]
                              :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}
-                                          nubank/matcher-combinators {:mvn/version "3.9.2"}}
+                                          nubank/matcher-combinators {:mvn/version "3.9.2"}
+                                          babashka/process {:mvn/version "0.6.23"}
+                                          babashka/fs {:mvn/version "0.5.27"}}
                              :main-opts   ["-m" "kaocha.runner" "--reporter" "documentation"]}
 
+               :create-settings-test {:exec-fn clj-watson.unit.controller.dependency-check.scanner-test/create-settings-test-entrypoint}
+               :create-settings-test-resources {:extra-paths ["target/create-settings-test"]}
+               
                ;; for dev: so we can run the recommended command from the README:
                :clj-watson {:replace-deps {io.github.clj-holmes/clj-watson {:local/root "."}}
                             :main-opts ["-m" "clj-watson.cli"]

--- a/src/clj_watson/controller/dependency_check/scanner.clj
+++ b/src/clj_watson/controller/dependency_check/scanner.clj
@@ -1,25 +1,15 @@
 (ns clj-watson.controller.dependency-check.scanner
   (:require
    [clj-watson.cli-spec :as cli-spec]
+   [clj-watson.logic.utils :as utils]
    [clojure.java.io :as io]
    [clojure.string :as string]
    [clojure.tools.logging :as log])
   (:import
-   (java.io ByteArrayInputStream File)
+   (java.nio.file Paths)
    (java.util Arrays)
    (org.owasp.dependencycheck Engine)
    (org.owasp.dependencycheck.utils Downloader Settings)))
-
-(defn- sanitize-property
-  "Given a line from a properties file, remove sensitive information."
-  [line]
-  (string/replace line
-                  #"(key=[-a-fA-F0-9]{4}).*([-a-fA-F0-9]{4})"
-                  "$1****-****-****-****-********$2"))
-
-(comment
-  ;; ensure (fake) API key is redacted:
-  (sanitize-property "nvd.api.key=72a48765-90ab-5678-abcd-1234abcd5489"))
 
 (defn ^:private env-var->property [env-var]
   (-> env-var
@@ -46,35 +36,44 @@
         (System/getenv))
   (println))
 
-(defn ^:private create-settings [^String properties-file-path ^String additional-properties-file-path]
+(defn ^:private resource-as-file [resource]
+  (when-let  [r (io/resource resource)]
+    (-> r .toURI Paths/get .toFile)))
+
+;; called from test
+(defn ^:private create-settings [^String watson-default-props-file ^String watson-user-props-file]
   (let [settings (Settings.)
-        props
-        (if properties-file-path
-          (->> properties-file-path File.)
-          (->> "dependency-check.properties" io/resource))]
-    (println (str "\nRead " (count (line-seq (io/reader props))) " dependency-check properties."))
-    (if properties-file-path
-      (->> props (.mergeProperties settings))
-      (->> props slurp .getBytes ByteArrayInputStream. (.mergeProperties settings)))
-    (if-let [add-props
-             (if additional-properties-file-path
-               (->> additional-properties-file-path File.)
-               (some->> "clj-watson.properties" io/resource))]
-      (do
-        (println "Merging additional properties:")
-        (try
-          (doseq [line (line-seq (io/reader add-props))]
-            (println (str "  " (sanitize-property line))))
-          (catch Exception e
-            (println (str "Unable to read: "
-                          (or additional-properties-file-path "clj-watson.properties")
-                          " due to: "
-                          (ex-message e)))))
-        (println "\n")
-        (if additional-properties-file-path
-          (->> add-props (.mergeProperties settings))
-          (some->> add-props slurp .getBytes ByteArrayInputStream. (.mergeProperties settings))))
-      (println "No additional properties found.\n"))
+        default-props-file
+        (if watson-default-props-file
+          (io/file watson-default-props-file)
+          (resource-as-file "dependency-check.properties"))
+        num-props (count (utils/load-properties default-props-file))
+        plural-props (fn [cnt] (if (= 1 cnt) "property" "properties"))]
+    (println (str "\nReading " num-props " dependency-check "
+                  (plural-props num-props)
+                  " from:\n " (.getCanonicalPath default-props-file)))
+    (with-open [in-stream (io/input-stream default-props-file)]
+      (.mergeProperties settings in-stream))
+    (if-let [user-props-file
+             (if watson-user-props-file
+               (->> watson-user-props-file io/file)
+               (resource-as-file "clj-watson.properties"))]
+      (let [props-to-merge (->> (utils/load-properties user-props-file)
+                                (into {})
+                                (into [])
+                                (sort-by first))
+            num-props-to-merge (count props-to-merge)]
+        (println (str "Merging " num-props-to-merge " additional clj-watson "
+                      (plural-props num-props-to-merge)
+                      " from:\n " (.getCanonicalPath user-props-file)))
+        (doseq [[k v] props-to-merge]
+          ;; similar to dependency check's odc.settings.mask, but more conservative
+          (println (str "  " k "=" (if (re-find #"(key|token|user|password|pw|secret)" k)
+                                     "***OCCLUDED***"
+                                     v)))
+          (.setString settings k v)))
+      (println "No additional clj-watson properties found."))
+    (println)
     (set-watson-env-vars-as-properties)
     settings))
 
@@ -136,3 +135,4 @@
     (if-let [exit (validate-settings settings opts)]
       exit
       (scan settings dependencies))))
+

--- a/src/clj_watson/logic/utils.clj
+++ b/src/clj_watson/logic/utils.clj
@@ -1,4 +1,8 @@
-(ns clj-watson.logic.utils)
+(ns clj-watson.logic.utils
+  (:require
+   [clojure.java.io :as io])
+  (:import
+   (java.util Properties)))
 
 (defn assoc-some
   "Associates a key with a value in a map, if and only if the value is
@@ -9,3 +13,11 @@
    (reduce (fn [m [k v]] (assoc-some m k v))
            (assoc-some m k v)
            (partition 2 kvs))))
+
+(defn load-properties
+  "Return `Properties` loaded from `source`."
+  [source]
+  (with-open [reader (io/reader source)]
+    (let [props (Properties.)]
+      (.load props reader)
+      props)))

--- a/test/clj_watson/unit/controller/dependency_check/scanner_test.clj
+++ b/test/clj_watson/unit/controller/dependency_check/scanner_test.clj
@@ -1,0 +1,146 @@
+(ns clj-watson.unit.controller.dependency-check.scanner-test
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as p]
+   [clj-watson.controller.dependency-check.scanner :as scanner]
+   [clj-watson.logic.utils :as utils]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [matcher-combinators.matchers :as m]
+   [matcher-combinators.test]))
+
+(def work-dir "target/create-settings-test")
+
+(deftest create-settings-test
+  ;; To truly test that settings are applied as expected, we need to spawn a process to
+  ;; set Java system properties and a environment variables.
+  ;; This is slow, so we are careful to limit the number of spawns.
+  ;;
+  ;; Precedence highest to lowest should be:
+  ;; :sys            - system property specified on command line
+  ;; :env-var        - environment variable
+  ;; :watson-user    - clj-watson clj-watson.properties
+  ;; :watson-default - clj-watson dependency-check.properties
+  ;; :dc-default     - dependency-check property default
+
+  (fs/delete-tree work-dir)
+  (fs/create-dirs work-dir)
+  (let [dc-defaults (->> (utils/load-properties (io/resource "dependencycheck.properties"))
+                         (into {}))
+        ;; Grab some actual valid properties from dependency check, update as necessary if properties change
+                   ;; prop name         expected-winner  applied in (:dc-default-prop defines expectation)
+        properties [["data.driver_name" :sys             #{:sys :env-var :watson-user :watson-default :dc-default}]
+                    ["cpe.url"          :env-var         #{:env-var :watson-user :watson-default :dc-default}]
+                    ;; multiple watson user props to test output value occlusion
+                    ["data.password"    :watson-user     #{:watson-user :watson-default :dc-default}]
+                    ["nvd.api.key"      :watson-user     #{:watson-user}] ;; nvd.api.key is not a dc default prop
+                    ["data.user"        :watson-user     #{:watson-user :watson-default :dc-default}]
+                    ["data.version"     :watson-user     #{:watson-user                 :dc-default}]
+                    ["data.file_name"   :watson-default  #{:watson-default :dc-default}]
+                    ["odc.autoupdate"   :dc-default      #{:dc-default}]]
+
+        in-settings (reduce (fn [acc [prop-name _ apply-in]]
+                              (let [v (get dc-defaults prop-name :not-set)]
+                                (cond
+                                  (and (apply-in :dc-default) (= :not-set v))
+                                  (throw (ex-info (format "pre-check failed: expected %s to be a dependency-check default" prop-name) {}))
+
+                                  (and (not (apply-in :dc-default)) (not= :not-set v))
+                                  (throw (ex-info (format "pre-check failed: expected %s NOT to be a dependency-check default" prop-name) {})))
+
+                                (cond-> acc
+                                  (apply-in :sys)
+                                  (update :sys conj (str "-J-D" prop-name "=" ":sys:-" v))
+
+                                  (apply-in :env-var)
+                                  (update :env-var assoc
+                                          (str "CLJ_WATSON_" (-> prop-name
+                                                                 (str/replace "_" "__")
+                                                                 (str/replace "." "_")
+                                                                 (str/upper-case)))
+                                          (str ":env-var:-" v))
+
+                                  (apply-in :watson-user)
+                                  (update :watson-user conj
+                                          (str prop-name "=" ":watson-user:-" v))
+
+                                  (apply-in :watson-default)
+                                  (update :watson-default conj
+                                          (str prop-name "=" ":watson-default:-" v)))))
+                            {:sys []
+                             :env-var {}
+                             :watson-user []
+                             :watson-default []}
+                            properties)
+        watson-default (->> in-settings :watson-default (str/join "\n"))
+        watson-user (->> in-settings :watson-user (str/join "\n"))
+        sys-env-vars (->> (System/getenv)
+                          (reduce-kv (fn [m k v]
+                                       (if (str/starts-with? k "CLJ_WATSON_")
+                                         m
+                                         (assoc m k v)))
+                                     {}))
+        env-vars (merge sys-env-vars (:env-var in-settings))
+        watson-default-file (str (fs/file work-dir "dependency-check.properties"))
+        watson-user-file (str (fs/file work-dir "clj-watson.properties"))
+        report-on-props (mapv first properties)]
+
+    (spit watson-default-file watson-default)
+    (spit watson-user-file watson-user)
+
+    (doseq [{:keys [args desc]} [{:desc "with explicit filenames"
+                                  :args (conj (into ["clojure"] (:sys in-settings))
+                                              "-X:test:create-settings-test"
+                                              ":watson-default-file" watson-default-file
+                                              ":watson-user-file" watson-user-file
+                                              ":report-on-props" (pr-str report-on-props))}
+                                 {:desc "with files found on classpath"
+                                  :args (conj (into ["clojure"] (:sys in-settings))
+                                              "-X:test:create-settings-test:create-settings-test-resources"
+                                              ":report-on-props" (pr-str report-on-props))}]]
+      (testing desc
+        (let [{:keys [out exit]} (apply p/shell {:continue true
+                                                 :out :string
+                                                 :err :string
+                                                 :env env-vars}
+                                        args)
+              expected-settings (reduce (fn [acc [prop-name expected-winner]]
+                                          (let [v (get dc-defaults prop-name :not-set)]
+                                            (assoc acc prop-name
+                                                   (if (= :dc-default expected-winner)
+                                                     v
+                                                     (str expected-winner ":-" v)))))
+                                        {}
+                                        properties)]
+          (is (zero? exit))
+          (is (match? (m/equals expected-settings) (edn/read-string (slurp (fs/file work-dir "result.edn"))))
+              "resulting settings")
+          (is (match? [""
+                       "Reading 5 dependency-check properties from:"
+                       #" .*/clj-watson/target/create-settings-test/dependency-check.properties"
+                       "Merging 6 additional clj-watson properties from:"
+                       #" .*/clj-watson/target/create-settings-test/clj-watson.properties"
+                       #"  cpe.url=:watson-user:-.+"
+                       #"  data.driver_name=:watson-user:-.+"
+                       "  data.password=***OCCLUDED***"
+                       "  data.user=***OCCLUDED***"
+                       #"  data.version=:watson-user:-.+"
+                       "  nvd.api.key=***OCCLUDED***"
+                       ""
+                       "Setting cpe.url from CLJ_WATSON_CPE_URL."
+                       "Ignoring CLJ_WATSON_DATA_DRIVER__NAME as data.driver_name is already set."]
+                      (str/split-lines out))
+              "stdout"))))))
+
+;; -X exec entrypoint for testing only
+(defn create-settings-test-entrypoint [{:keys [watson-default-file watson-user-file report-on-props]}]
+  (let [watson-default-file (when watson-default-file (str watson-default-file))
+        watson-user-file (when watson-user-file (str watson-user-file))]
+    (fs/create-dirs work-dir)
+    (let [settings (#'scanner/create-settings watson-default-file watson-user-file)]
+      (spit (fs/file work-dir "result.edn") (pr-str (reduce (fn [acc n]
+                                                              (assoc acc n (.getString settings n)))
+                                                            {}
+                                                            report-on-props))))))


### PR DESCRIPTION
Use the same strategy as dependency-check, but more conservative.

Any property with a sensitive looking name will now print as `***OCCLUDED***`.

Closes #141

Also now:
- no longer printing `clj-watson.properties` content (it might be any invalid file), rather instead, we print the properties that are found in the file
- calculating the number of properties in `dependency-check.properties` by actual properties found rather than line count
- no longer catching and printing an exceptions when loading `clj-watson.properties`. Load issues of this file should be exceptional and fatal. (Note also that cli now validates file existence).
- printing the properties filenames
- printing count of properties found for clj-watson properties; we do show the actual properties, but nice to see the count too. Users will likely especially appreciate this when 0 properties are found.
- testing precedence of dependency-check settings